### PR TITLE
Update the crypto library to use the new noise parameter type.

### DIFF
--- a/cross-media-measurement/src/main/cc/wfa/measurement/common/crypto/BUILD.bazel
+++ b/cross-media-measurement/src/main/cc/wfa/measurement/common/crypto/BUILD.bazel
@@ -139,6 +139,7 @@ cc_library(
     deps = [
         ":constants",
         ":encryption_utility_helper",
+        ":noise_parameters_computation",
         ":protocol_cryptor",
         ":started_thread_cpu_timer",
         "//src/main/cc/wfa/measurement/common:macros",

--- a/cross-media-measurement/src/main/cc/wfa/measurement/common/crypto/liquid_legions_v2_encryption_utility.cc
+++ b/cross-media-measurement/src/main/cc/wfa/measurement/common/crypto/liquid_legions_v2_encryption_utility.cc
@@ -22,6 +22,7 @@
 #include "src/main/cc/estimation/estimators.h"
 #include "wfa/measurement/common/crypto/constants.h"
 #include "wfa/measurement/common/crypto/encryption_utility_helper.h"
+#include "wfa/measurement/common/crypto/noise_parameters_computation.h"
 #include "wfa/measurement/common/crypto/protocol_cryptor.h"
 #include "wfa/measurement/common/crypto/started_thread_cpu_timer.h"
 #include "wfa/measurement/common/macros.h"
@@ -190,25 +191,17 @@ absl::Status EncryptCompositeElGamalAndAppendToString(
   return absl::OkStatus();
 }
 
-math::DistributedGeometricRandomComponentOptions ToOptions(
-    const DistributedGeometricDistributionParams& params) {
-  return {.num = params.num(),
-          .p = params.p(),
-          .truncate_threshold = params.shift_offset(),
-          .shift_offset = params.shift_offset()};
-}
-
 // Adds encrypted blinded-histogram-noise registers to the end of data.
 // returns the number of such noise registers added.
 absl::StatusOr<int64_t> AddBlindedHistogramNoise(
     ProtocolCryptor& protocol_cryptor, int total_sketches_count,
-    const DistributedGeometricDistributionParams& params, std::string& data) {
+    const math::DistributedGeometricRandomComponentOptions& options,
+    std::string& data) {
   ASSIGN_OR_RETURN(
       std::string blinded_histogram_noise_key_ec,
       protocol_cryptor.MapToCurve(kBlindedHistogramNoiseRegisterKey));
 
   int64_t noise_register_added = 0;
-  math::DistributedGeometricRandomComponentOptions options = ToOptions(params);
   for (int k = 1; k <= total_sketches_count; ++k) {
     // The random number of distinct register_ids that should appear k times.
     ASSIGN_OR_RETURN(int64_t noise_register_count_for_bucket_k,
@@ -244,13 +237,13 @@ absl::StatusOr<int64_t> AddBlindedHistogramNoise(
 // returns the number of such noise registers added.
 absl::StatusOr<int64_t> AddNoiseForPublisherNoise(
     ProtocolCryptor& protocol_cryptor,
-    const DistributedGeometricDistributionParams& params, std::string& data) {
+    const math::DistributedGeometricRandomComponentOptions& options,
+    std::string& data) {
   ASSIGN_OR_RETURN(std::string publisher_noise_register_id_ec,
                    protocol_cryptor.MapToCurve(kPublisherNoiseRegisterId));
 
-  ASSIGN_OR_RETURN(
-      int64_t noise_registers_count,
-      math::GetDistributedGeometricRandomComponent(ToOptions(params)));
+  ASSIGN_OR_RETURN(int64_t noise_registers_count,
+                   math::GetDistributedGeometricRandomComponent(options));
   for (int i = 0; i < noise_registers_count; ++i) {
     // Add register id, a predefined constant.
     RETURN_IF_ERROR(EncryptCompositeElGamalAndAppendToString(
@@ -273,13 +266,13 @@ absl::StatusOr<int64_t> AddNoiseForPublisherNoise(
 // returns the number of such noise registers added.
 absl::StatusOr<int64_t> AddGlobalReachDpNoise(
     ProtocolCryptor& protocol_cryptor,
-    const DistributedGeometricDistributionParams& params, std::string& data) {
+    const math::DistributedGeometricRandomComponentOptions& options,
+    std::string& data) {
   ASSIGN_OR_RETURN(std::string destroyed_register_key_ec,
                    protocol_cryptor.MapToCurve(kDestroyedRegisterKey));
 
-  ASSIGN_OR_RETURN(
-      int64_t noise_registers_count,
-      math::GetDistributedGeometricRandomComponent(ToOptions(params)));
+  ASSIGN_OR_RETURN(int64_t noise_registers_count,
+                   math::GetDistributedGeometricRandomComponent(options));
   for (int i = 0; i < noise_registers_count; ++i) {
     // Add register id, a random number.
     // The prefix is to ensure the value is not in the regular id space.
@@ -332,12 +325,11 @@ absl::Status AddPaddingReachNoise(ProtocolCryptor& protocol_cryptor,
 absl::StatusOr<int64_t> AddFrequencyDpNoise(
     ProtocolCryptor& full_protocol_cryptor,
     ProtocolCryptor& partial_protocol_cryptor, int maximum_frequency,
-    int curve_id, const DistributedGeometricDistributionParams& params,
+    int curve_id,
+    const math::DistributedGeometricRandomComponentOptions& options,
     std::string& data) {
   ASSIGN_OR_RETURN(std::vector<std::string> count_values_plaintext,
                    GetCountValuesPlaintext(maximum_frequency, curve_id));
-
-  math::DistributedGeometricRandomComponentOptions options = ToOptions(params);
   int total_noise_tuples_added = 0;
   for (int frequency = 1; frequency <= maximum_frequency; ++frequency) {
     ASSIGN_OR_RETURN(int64_t noise_tuples_count,
@@ -374,10 +366,10 @@ absl::StatusOr<int64_t> AddFrequencyDpNoise(
 absl::StatusOr<int64_t> AddDestroyedFrequencyNoise(
     ProtocolCryptor& full_protocol_cryptor,
     ProtocolCryptor& partial_protocol_cryptor,
-    const DistributedGeometricDistributionParams& params, std::string& data) {
-  ASSIGN_OR_RETURN(
-      int64_t noise_tuples_count,
-      math::GetDistributedGeometricRandomComponent(ToOptions(params)));
+    const math::DistributedGeometricRandomComponentOptions& options,
+    std::string& data) {
+  ASSIGN_OR_RETURN(int64_t noise_tuples_count,
+                   math::GetDistributedGeometricRandomComponent(options));
   for (int i = 0; i < noise_tuples_count; ++i) {
     for (int j = 0; j < 3; ++j) {
       // Add three random flags encrypted using the partial_protocol_cryptor.
@@ -432,43 +424,48 @@ absl::Status AddPaddingFrequencyNoise(ProtocolCryptor& full_protocol_cryptor,
 
 absl::Status ValidateSetupNoiseParameters(
     const RegisterNoiseGenerationParameters& parameters) {
-  int64_t total_register_count = parameters.total_noise_registers_count();
-  int64_t sketch_count = parameters.total_sketches_count();
-  int64_t blind_histogram_noise_offset =
-      parameters.blind_histogram_noise_parameters().shift_offset();
-  int64_t reach_dp_noise_offset =
-      parameters.global_reach_dp_noise_parameters().shift_offset();
-  int64_t publisher_noise_offset =
-      parameters.publisher_noise_parameters().shift_offset();
-
-  if (sketch_count < 1) {
-    return absl::InvalidArgumentError("sketch count should be positive.");
+  if (parameters.contributors_count() < 1) {
+    return absl::InvalidArgumentError("contributors_count should be positive.");
   }
-  if (blind_histogram_noise_offset < 1 || reach_dp_noise_offset < 1 ||
-      publisher_noise_offset < 1) {
-    return absl::InvalidArgumentError("shift_offset should be positive.");
+  if (parameters.total_sketches_count() < 1) {
+    return absl::InvalidArgumentError(
+        "total_sketches_count should be positive.");
   }
-  int64_t min_register_count =
-      publisher_noise_offset * 2 + reach_dp_noise_offset * 2 +
-      blind_histogram_noise_offset * sketch_count * (sketch_count + 1);
-  if (total_register_count < min_register_count) {
-    return absl::InvalidArgumentError(absl::StrCat(
-        "total_noise_registers_count should be at least ", min_register_count));
+  if (parameters.dp_params().blind_histogram().epsilon() <= 0 ||
+      parameters.dp_params().blind_histogram().delta() <= 0) {
+    return absl::InvalidArgumentError(
+        "Invalid blind_histogram dp parameter. epsilon/delta should be "
+        "positive.");
+  }
+  if (parameters.dp_params().noise_for_publisher_noise().epsilon() <= 0 ||
+      parameters.dp_params().noise_for_publisher_noise().delta() <= 0) {
+    return absl::InvalidArgumentError(
+        "Invalid noise_for_publisher_noise dp parameter. epsilon/delta should "
+        "be positive.");
+  }
+  if (parameters.dp_params().global_reach_dp_noise().epsilon() <= 0 ||
+      parameters.dp_params().global_reach_dp_noise().delta() <= 0) {
+    return absl::InvalidArgumentError(
+        "Invalid global_reach_dp_noise dp parameter. epsilon/delta should be "
+        "positive.");
   }
   return absl::OkStatus();
 }
 
 absl::Status ValidateFrequencyNoiseParameters(
     const FlagCountTupleNoiseGenerationParameters& parameters) {
-  int total_tuple_count = parameters.total_noise_tuples_count();
-  int min_tuple_count =
-      parameters.non_destroyed_noise_parameters().shift_offset() * 2 *
-          parameters.maximum_frequency() +
-      parameters.destroyed_noise_parameters().shift_offset() * 2;
-
-  if (total_tuple_count < min_tuple_count) {
-    return absl::InvalidArgumentError(absl::StrCat(
-        "total_noise_tuples_count should be at least ", min_tuple_count));
+  if (parameters.contributors_count() < 1) {
+    return absl::InvalidArgumentError("contributors_count should be positive.");
+  }
+  if (parameters.maximum_frequency() < 2) {
+    return absl::InvalidArgumentError(
+        "maximum_frequency should be at least 2.");
+  }
+  if (parameters.dp_params().epsilon() <= 0 ||
+      parameters.dp_params().delta() <= 0) {
+    return absl::InvalidArgumentError(
+        "Invalid frequency noise dp parameter. epsilon/delta should be "
+        "positive.");
   }
   return absl::OkStatus();
 }
@@ -479,17 +476,22 @@ absl::Status AddAllFrequencyNoise(
     const FlagCountTupleNoiseGenerationParameters& noise_parameters,
     std::string& data) {
   RETURN_IF_ERROR(ValidateFrequencyNoiseParameters(noise_parameters));
+
+  auto options = GetFrequencyNoiseOptions(
+      noise_parameters.dp_params(), noise_parameters.maximum_frequency(),
+      noise_parameters.contributors_count());
+  int total_noise_tuples_count =
+      options.shift_offset * 2 * (noise_parameters.maximum_frequency() + 1);
   ASSIGN_OR_RETURN(
       int frequency_dp_noise_tuples_count,
       AddFrequencyDpNoise(full_protocol_cryptor, partial_protocol_cryptor,
                           noise_parameters.maximum_frequency(), curve_id,
-                          noise_parameters.non_destroyed_noise_parameters(),
-                          data));
-  ASSIGN_OR_RETURN(int destroyed_noise_tuples_count,
-                   AddDestroyedFrequencyNoise(
-                       full_protocol_cryptor, partial_protocol_cryptor,
-                       noise_parameters.destroyed_noise_parameters(), data));
-  int padding_noise_tuples_count = noise_parameters.total_noise_tuples_count() -
+                          options, data));
+  ASSIGN_OR_RETURN(
+      int destroyed_noise_tuples_count,
+      AddDestroyedFrequencyNoise(full_protocol_cryptor,
+                                 partial_protocol_cryptor, options, data));
+  int padding_noise_tuples_count = total_noise_tuples_count -
                                    frequency_dp_noise_tuples_count -
                                    destroyed_noise_tuples_count;
   RETURN_IF_ERROR(AddPaddingFrequencyNoise(full_protocol_cryptor,
@@ -511,9 +513,27 @@ absl::StatusOr<CompleteSetupPhaseResponse> CompleteSetupPhase(
   if (request.has_noise_parameters()) {
     RegisterNoiseGenerationParameters noise_parameters =
         request.noise_parameters();
+    auto blind_histogram_noise_options = GetBlindHistogramNoiseOptions(
+        noise_parameters.dp_params().blind_histogram(),
+        noise_parameters.total_sketches_count(),
+        noise_parameters.contributors_count());
+    auto noise_for_publisher_noise_options = GetNoiseForPublisherNoiseOptions(
+        noise_parameters.dp_params().noise_for_publisher_noise(),
+        noise_parameters.total_sketches_count(),
+        noise_parameters.contributors_count());
+    auto global_reach_dp_noise_options = GetGlobalReachDpNoiseOptions(
+        noise_parameters.dp_params().global_reach_dp_noise(),
+        noise_parameters.contributors_count());
+    int total_noise_registers_count =
+        noise_for_publisher_noise_options.shift_offset * 2 +
+        global_reach_dp_noise_options.shift_offset * 2 +
+        blind_histogram_noise_options.shift_offset *
+            noise_parameters.total_sketches_count() *
+            (noise_parameters.total_sketches_count() + 1);
+
     // reserve the space to hold all output data.
     response_crv->reserve(request.combined_register_vector().size() +
-                          noise_parameters.total_noise_registers_count() *
+                          total_noise_registers_count *
                               kBytesPerCipherRegister);
 
     RETURN_IF_ERROR(ValidateSetupNoiseParameters(noise_parameters));
@@ -530,27 +550,23 @@ absl::StatusOr<CompleteSetupPhaseResponse> CompleteSetupPhase(
     // 1. Add blinded histogram noise.
     ASSIGN_OR_RETURN(
         int64_t blinded_histogram_noise_count,
-        AddBlindedHistogramNoise(
-            *protocol_cryptor, noise_parameters.total_sketches_count(),
-            noise_parameters.blind_histogram_noise_parameters(),
-            *response_crv));
+        AddBlindedHistogramNoise(*protocol_cryptor,
+                                 noise_parameters.total_sketches_count(),
+                                 blind_histogram_noise_options, *response_crv));
     // 2. Add noise for publisher noise.
-    ASSIGN_OR_RETURN(
-        int64_t publisher_noise_count,
-        AddNoiseForPublisherNoise(*protocol_cryptor,
-                                  noise_parameters.publisher_noise_parameters(),
-                                  *response_crv));
-    // 3. Add reach DP noise.
-    ASSIGN_OR_RETURN(int64_t reach_dp_noise_count,
-                     AddGlobalReachDpNoise(
-                         *protocol_cryptor,
-                         noise_parameters.global_reach_dp_noise_parameters(),
+    ASSIGN_OR_RETURN(int64_t publisher_noise_count,
+                     AddNoiseForPublisherNoise(
+                         *protocol_cryptor, noise_for_publisher_noise_options,
                          *response_crv));
+    // 3. Add reach DP noise.
+    ASSIGN_OR_RETURN(
+        int64_t reach_dp_noise_count,
+        AddGlobalReachDpNoise(*protocol_cryptor, global_reach_dp_noise_options,
+                              *response_crv));
     // 4. Add padding noise.
-    int64_t padding_noise_count =
-        noise_parameters.total_noise_registers_count() -
-        blinded_histogram_noise_count - publisher_noise_count -
-        reach_dp_noise_count;
+    int64_t padding_noise_count = total_noise_registers_count -
+                                  blinded_histogram_noise_count -
+                                  publisher_noise_count - reach_dp_noise_count;
     RETURN_IF_ERROR(AddPaddingReachNoise(*protocol_cryptor, padding_noise_count,
                                          *response_crv));
   }
@@ -785,12 +801,16 @@ CompleteExecutionPhaseTwoAtAggregator(
   }
 
   // Estimates reach.
-  int64_t active_register_count = tuple_counts - blinded_histogram_noise_count -
-                                  request.global_reach_dp_noise_baseline();
-  if (request.global_reach_dp_noise_baseline() > 0) {
+  int64_t active_register_count = tuple_counts - blinded_histogram_noise_count;
+  if (request.has_noise_baseline()) {
+    auto options = GetGlobalReachDpNoiseOptions(
+        request.noise_baseline().global_reach_dp_noise(),
+        request.noise_baseline().contributors_count());
+    int global_reach_dp_noise_baseline = options.shift_offset * options.num;
+    active_register_count -= global_reach_dp_noise_baseline;
     // Publisher noise and padding noise each contribute 1 additional destroyed
     // register, which shouldn't be included when estimating reach.
-    // Deletes 2 from the active_register_count if noises exist.
+    // Subtracts 2 from the active_register_count if noises exist.
     active_register_count -= 2;
   }
   // Ensures that active_register_count is at least 0.
@@ -905,19 +925,24 @@ CompleteExecutionPhaseThreeAtAggregator(
     }
   }
 
+  int valid_tuple_count = column_size;
   // Adjusts the histogram according the noise baseline.
-  int noise_baseline_per_bucket =
-      request.global_frequency_dp_noise_baseline_per_bucket();
-
-  int actual_total = 0;
-  for (int i = 0; i < maximum_frequency; ++i) {
-    histogram[i] = std::max(0, histogram[i] - noise_baseline_per_bucket);
-    actual_total += histogram[i];
-  }
-
-  if (actual_total == 0) {
-    return absl::InvalidArgumentError(
-        "There is neither acutal data nor effective noise in the request.");
+  if (request.has_global_frequency_dp_noise_per_bucket()) {
+    auto options = GetFrequencyNoiseOptions(
+        request.global_frequency_dp_noise_per_bucket().dp_params(),
+        request.maximum_frequency(),
+        request.global_frequency_dp_noise_per_bucket().contributors_count());
+    int noise_baseline_per_bucket = options.shift_offset * options.num;
+    int actual_total = 0;
+    for (int i = 0; i < maximum_frequency; ++i) {
+      histogram[i] = std::max(0, histogram[i] - noise_baseline_per_bucket);
+      actual_total += histogram[i];
+    }
+    if (actual_total == 0) {
+      return absl::InvalidArgumentError(
+          "There is neither actual data nor effective noise in the request.");
+    }
+    valid_tuple_count = actual_total;
   }
 
   CompleteExecutionPhaseThreeAtAggregatorResponse response;
@@ -925,7 +950,8 @@ CompleteExecutionPhaseThreeAtAggregator(
       *response.mutable_frequency_distribution();
   for (int i = 0; i < maximum_frequency; ++i) {
     if (histogram[i] != 0) {
-      distribution[i + 1] = static_cast<double>(histogram[i]) / actual_total;
+      distribution[i + 1] =
+          static_cast<double>(histogram[i]) / valid_tuple_count;
     }
   }
   response.set_elapsed_cpu_time_millis(timer.ElapsedMillis());

--- a/cross-media-measurement/src/main/proto/wfa/measurement/common/crypto/liquid_legions_v2_encryption_methods.proto
+++ b/cross-media-measurement/src/main/proto/wfa/measurement/common/crypto/liquid_legions_v2_encryption_methods.proto
@@ -50,7 +50,7 @@ message RegisterNoiseGenerationParameters {
   ElGamalPublicKey composite_el_gamal_public_key = 1;
   // The elliptical curve to work on.
   int64 curve_id = 2;
-  // Number of contributors to the noise.
+  // The number of honest parties contributing their noise.
   int32 contributors_count = 3;
   // The total number of sketches across all workers for this computation.
   int32 total_sketches_count = 4;
@@ -61,7 +61,7 @@ message RegisterNoiseGenerationParameters {
 message FlagCountTupleNoiseGenerationParameters {
   // Maximum frequency to measure.
   int32 maximum_frequency = 1;
-  // Number of contributors to the noise.
+  // The number of honest parties contributing their noise.
   int32 contributors_count = 2;
   // Differential privacy parameters for noise tuples.
   // Same value is used for both (0, R, R) and (R, R, R) tuples.
@@ -69,14 +69,14 @@ message FlagCountTupleNoiseGenerationParameters {
 }
 
 message GlobalReachDpNoiseBaseline {
-  // Number of contributors to the noise.
+  // The number of honest parties contributing their noise.
   int32 contributors_count = 1;
   // DP parameters used when adding the global reach DP noise registers.
   DifferentialPrivacyParams global_reach_dp_noise = 2;
 }
 
 message PerBucketFrequencyDpNoiseBaseline {
-  // Number of contributors to the noise.
+  // The number of honest parties contributing their noise.
   int32 contributors_count = 1;
   // DP parameters used when adding noise.
   DifferentialPrivacyParams dp_params = 2;

--- a/cross-media-measurement/src/main/proto/wfa/measurement/common/crypto/liquid_legions_v2_encryption_methods.proto
+++ b/cross-media-measurement/src/main/proto/wfa/measurement/common/crypto/liquid_legions_v2_encryption_methods.proto
@@ -50,36 +50,36 @@ message RegisterNoiseGenerationParameters {
   ElGamalPublicKey composite_el_gamal_public_key = 1;
   // The elliptical curve to work on.
   int64 curve_id = 2;
-  // The total number of noise registers to be added.
-  // The value should be at least equal to
-  //   publisher_noise_parameters.offset * 2
-  //   + global_reach_dp_noise_parameters.offset * 2
-  //   + blind_histogram_noise_parameters.offset * total_sketches_count
-  //   * (total_sketches_count + 1).
-  // TODO: add link to the external paper.
-  int32 total_noise_registers_count = 3;
+  // Number of contributors to the noise.
+  int32 contributors_count = 3;
   // The total number of sketches across all workers for this computation.
   int32 total_sketches_count = 4;
-  // TODO: replace the following 3 using ReachNoiseDifferentialPrivacyParams
-  DistributedGeometricDistributionParams blind_histogram_noise_parameters = 5;
-  DistributedGeometricDistributionParams publisher_noise_parameters = 6;
-  DistributedGeometricDistributionParams global_reach_dp_noise_parameters = 7;
+  // Differential privacy parameters for all noise types.
+  ReachNoiseDifferentialPrivacyParams dp_params = 5;
 }
 
 message FlagCountTupleNoiseGenerationParameters {
   // Maximum frequency to measure.
   int32 maximum_frequency = 1;
-  // The total number of noise tuples to be added.
-  // The value should be at least equal to
-  //   non_destroyed_noise_parameters.offset*2*maximum_frequency
-  //     + destroyed_noise_parameters.offset*2
-  int32 total_noise_tuples_count = 2;
-  // TODO: replace the following 2 using a same DifferentialPrivacyParams
-  // The distribution of the number of noise tuples with flag (0, R, R) in each
-  // bucket. In total, there are maximum_frequency such buckets.
-  DistributedGeometricDistributionParams non_destroyed_noise_parameters = 3;
-  // The distribution of the number of noise tuples with flag (R, R, R).
-  DistributedGeometricDistributionParams destroyed_noise_parameters = 4;
+  // Number of contributors to the noise.
+  int32 contributors_count = 2;
+  // Differential privacy parameters for noise tuples.
+  // Same value is used for both (0, R, R) and (R, R, R) tuples.
+  DifferentialPrivacyParams dp_params = 3;
+}
+
+message GlobalReachDpNoiseBaseline {
+  // Number of contributors to the noise.
+  int32 contributors_count = 1;
+  // DP parameters used when adding the global reach DP noise registers.
+  DifferentialPrivacyParams global_reach_dp_noise = 2;
+}
+
+message PerBucketFrequencyDpNoiseBaseline {
+  // Number of contributors to the noise.
+  int32 contributors_count = 1;
+  // DP parameters used when adding noise.
+  DifferentialPrivacyParams dp_params = 2;
 }
 
 // The request to complete work in the setup phase.
@@ -216,12 +216,10 @@ message CompleteExecutionPhaseTwoAtAggregatorRequest {
   int32 maximum_frequency = 5;
   // LiquidLegions parameters used for reach estimation.
   LiquidLegionsParameters liquid_legions_parameters = 6;
-  // Global Reach DP noise baseline. i.e. the mean of the global two-sided
-  // distributed random variable. non-negative.
-  // If =0, it means no noise (including non-DP noises) was added.
-  // If >0, the value should be equal to
-  // global_reach_dp_noise_parameters.shift_offset*num used in the setup phase.
-  int64 global_reach_dp_noise_baseline = 7;
+  // Parameters for computing the noise baseline of the global reach DP noise
+  // registers added in the setup phase.
+  // The baseline is subtracted before reach is estimated.
+  GlobalReachDpNoiseBaseline noise_baseline = 7;
 }
 
 // The response of the CompleteExecutionPhaseTwoAtAggregator method.
@@ -276,11 +274,9 @@ message CompleteExecutionPhaseThreeAtAggregatorRequest {
   int64 curve_id = 3;
   // Maximum frequency to output in the result. At least 2.
   int32 maximum_frequency = 4;
-  // Global frequency noise baseline for each bucket. i.e. the mean of the
-  // global two-sided distributed random variable. non-negative.
-  // If noise was added, the value should be equal to
-  // #(workers)*non_destroyed_noise_parameters.shift_offset used by all workers.
-  int64 global_frequency_dp_noise_baseline_per_bucket = 5;
+  // Parameters for computing the noise baseline of the frequency DP noise
+  // added. The baseline is subtracted before frequency is estimated.
+  PerBucketFrequencyDpNoiseBaseline global_frequency_dp_noise_per_bucket = 5;
 }
 
 // The response of the CompleteExecutionPhaseThreeAtAggregator method.

--- a/cross-media-measurement/src/test/cc/wfa/measurement/common/crypto/liquid_legions_v2_encryption_utility_test.cc
+++ b/cross-media-measurement/src/test/cc/wfa/measurement/common/crypto/liquid_legions_v2_encryption_utility_test.cc
@@ -90,13 +90,11 @@ Sketch CreateEmptyLiquidLegionsSketch() {
   return plain_sketch;
 }
 
-DistributedGeometricDistributionParams DistributedGeoParams(int64_t num,
-                                                            double p,
-                                                            int64_t offset) {
-  DistributedGeometricDistributionParams params;
-  params.set_num(num);
-  params.set_p(p);
-  params.set_shift_offset(offset);
+DifferentialPrivacyParams NewDifferentialPrivacyParams(double epsilon,
+                                                       double delta) {
+  DifferentialPrivacyParams params;
+  params.set_epsilon(epsilon);
+  params.set_delta(delta);
   return params;
 }
 
@@ -479,10 +477,12 @@ class TestData {
         ->set_size(kLiquidLegionsSize);
     if (reach_noise_parameters != nullptr) {
       complete_execution_phase_two_at_aggregator_request
-          .set_global_reach_dp_noise_baseline(
-              reach_noise_parameters->global_reach_dp_noise_parameters()
-                  .shift_offset() *
-              3);
+          .mutable_noise_baseline()
+          ->set_contributors_count(3);
+      *complete_execution_phase_two_at_aggregator_request
+           .mutable_noise_baseline()
+           ->mutable_global_reach_dp_noise() =
+          reach_noise_parameters->dp_params().global_reach_dp_noise();
     }
     complete_execution_phase_two_at_aggregator_request.set_flag_count_tuples(
         complete_execution_phase_two_response_2.flag_count_tuples());
@@ -532,11 +532,12 @@ class TestData {
             complete_execution_phase_three_response_2
                 .same_key_aggregator_matrix());
     if (frequency_noise_paraters != nullptr) {
-      DistributedGeometricDistributionParams non_destroyed =
-          frequency_noise_paraters->non_destroyed_noise_parameters();
+      *complete_execution_phase_three_at_aggregator_request
+           .mutable_global_frequency_dp_noise_per_bucket()
+           ->mutable_dp_params() = frequency_noise_paraters->dp_params();
       complete_execution_phase_three_at_aggregator_request
-          .set_global_frequency_dp_noise_baseline_per_bucket(
-              non_destroyed.shift_offset() * non_destroyed.num());
+          .mutable_global_frequency_dp_noise_per_bucket()
+          ->set_contributors_count(3);
     }
 
     ASSIGN_OR_RETURN(CompleteExecutionPhaseThreeAtAggregatorResponse
@@ -565,42 +566,51 @@ TEST(CompleteSetupPhase, NoiseSumAndMeanShouldBeCorrect) {
   public_key.set_generator(public_key_pair.first);
   public_key.set_element(public_key_pair.second);
 
-  int64_t num = 3;
-  // Set p to ~0, such that the shifted truncated diff would be equal to the
-  // shift_offset in the test.
-  double p = 0.000001;
-  int64_t blinded_histogram_noise_offset = 5;
-  int64_t publisher_noise_offset = 6;
-  int64_t reach_dp_noise_offset = 7;
-  int64_t total_sketch_count = 5;
-  int64_t total_register_count = 200;
+  int publisher_count = 3;
+  int num = 3;
+  // resulted p ~= 0 , offset = 7
+  auto blind_histogram_noise_param =
+      NewDifferentialPrivacyParams(40, std::exp(-80));
+  // resulted p ~= 0 , offset = 4
+  auto noise_for_publisher_noise_param =
+      NewDifferentialPrivacyParams(40, std::exp(-40));
+  // resulted p ~= 0 , offset = 3
+  auto reach_dp_noise_param = NewDifferentialPrivacyParams(40, std::exp(-80));
+
+  int64_t computed_blinded_histogram_noise_offset = 7;
+  int64_t computed_publisher_noise_offset = 4;
+  int64_t computed_reach_dp_noise_offset = 3;
+  int64_t expected_total_register_count =
+      computed_publisher_noise_offset * 2 + computed_reach_dp_noise_offset * 2 +
+      computed_blinded_histogram_noise_offset * publisher_count *
+          (publisher_count + 1);
 
   CompleteSetupPhaseRequest request;
   auto noise_parameters = request.mutable_noise_parameters();
   noise_parameters->set_curve_id(kTestCurveId);
-  noise_parameters->set_total_sketches_count(total_sketch_count);
-  noise_parameters->set_total_noise_registers_count(total_register_count);
-  *noise_parameters->mutable_blind_histogram_noise_parameters() =
-      DistributedGeoParams(num, p, blinded_histogram_noise_offset);
-  *noise_parameters->mutable_publisher_noise_parameters() =
-      DistributedGeoParams(num, p, publisher_noise_offset);
-  *noise_parameters->mutable_global_reach_dp_noise_parameters() =
-      DistributedGeoParams(num, p, reach_dp_noise_offset);
+  noise_parameters->set_total_sketches_count(publisher_count);
+  noise_parameters->set_contributors_count(num);
   *noise_parameters->mutable_composite_el_gamal_public_key() = public_key;
+  *noise_parameters->mutable_dp_params()->mutable_blind_histogram() =
+      blind_histogram_noise_param;
+  *noise_parameters->mutable_dp_params()->mutable_noise_for_publisher_noise() =
+      noise_for_publisher_noise_param;
+  *noise_parameters->mutable_dp_params()->mutable_global_reach_dp_noise() =
+      reach_dp_noise_param;
 
   ASSERT_OK_AND_ASSIGN(auto response, CompleteSetupPhase(request));
   // There was no data in the request, so all registers in the response are
   // noise.
   std::string noises = response.combined_register_vector();
-  ASSERT_THAT(noises,
-              SizeIs(total_register_count * kBytesPerEncryptedRegister));
+  ASSERT_THAT(noises, SizeIs(expected_total_register_count *
+                             kBytesPerEncryptedRegister));
 
   int64_t blinded_histogram_noise_count = 0;
   int64_t publisher_noise_count = 0;
   int64_t reach_dp_noise_count = 0;
   int64_t padding_noise_count = 0;
 
-  for (int i = 0; i < total_register_count; ++i) {
+  for (int i = 0; i < expected_total_register_count; ++i) {
     ASSERT_OK_AND_ASSIGN(
         bool is_blinded_histogram_noise,
         IsBlindedHistogramNoise(*el_gamal_cipher, ec_group,
@@ -631,14 +641,14 @@ TEST(CompleteSetupPhase, NoiseSumAndMeanShouldBeCorrect) {
               1);
   }
 
-  EXPECT_EQ(publisher_noise_count, publisher_noise_offset);
-  EXPECT_EQ(blinded_histogram_noise_count, blinded_histogram_noise_offset *
-                                               total_sketch_count *
-                                               (total_sketch_count + 1) / 2);
-  EXPECT_EQ(reach_dp_noise_count, reach_dp_noise_offset);
-  EXPECT_EQ(padding_noise_count, total_register_count - publisher_noise_count -
-                                     blinded_histogram_noise_count -
-                                     reach_dp_noise_count);
+  EXPECT_EQ(publisher_noise_count, computed_publisher_noise_offset);
+  EXPECT_EQ(blinded_histogram_noise_count,
+            computed_blinded_histogram_noise_offset * publisher_count *
+                (publisher_count + 1) / 2);
+  EXPECT_EQ(reach_dp_noise_count, computed_reach_dp_noise_offset);
+  EXPECT_EQ(padding_noise_count,
+            expected_total_register_count - publisher_noise_count -
+                blinded_histogram_noise_count - reach_dp_noise_count);
 }
 
 TEST(CompleteSetupPhase, WrongInputSketchSizeShouldThrow) {
@@ -714,9 +724,9 @@ TEST(CompleteExecutionPhaseThreeAtAggregator, WrongInputSketchSizeShouldThrow) {
 TEST(EndToEnd, SumOfCountsShouldBeCorrect) {
   TestData test_data;
   Sketch plain_sketch = CreateEmptyLiquidLegionsSketch();
-  AddRegister(&plain_sketch, /* index = */ 1, /* key = */ 111, /* count = */ 1);
-  AddRegister(&plain_sketch, /* index = */ 1, /* key = */ 111, /* count = */ 2);
-  AddRegister(&plain_sketch, /* index = */ 1, /* key = */ 111, /* count = */ 3);
+  AddRegister(&plain_sketch, /*index=*/1, /*key=*/111, /*count=*/1);
+  AddRegister(&plain_sketch, /*index=*/1, /*key=*/111, /*count=*/2);
+  AddRegister(&plain_sketch, /*index=*/1, /*key=*/111, /*count=*/3);
 
   std::string encrypted_sketch =
       test_data.EncryptWithFlaggedKey(plain_sketch).value();
@@ -733,9 +743,9 @@ TEST(EndToEnd, SumOfCountsShouldBeCorrect) {
 TEST(EndToEnd, LocallyDistroyedRegisterShouldBeIgnored) {
   TestData test_data;
   Sketch plain_sketch = CreateEmptyLiquidLegionsSketch();
-  AddRegister(&plain_sketch, /* index = */ 1, /* key = */ 111, /* count = */ 3);
-  AddRegister(&plain_sketch, /* index = */ 2, /* key = */ -1,
-              /* count = */ 2);  // locally destroyed.
+  AddRegister(&plain_sketch, /*index=*/1, /*key=*/111, /*count=*/3);
+  AddRegister(&plain_sketch, /*index=*/2, /*key=*/-1,
+              /*count=*/2);  // locally destroyed.
 
   std::string encrypted_sketch =
       test_data.EncryptWithFlaggedKey(plain_sketch).value();
@@ -752,9 +762,9 @@ TEST(EndToEnd, LocallyDistroyedRegisterShouldBeIgnored) {
 TEST(EndToEnd, CrossPublisherDistroyedRegistersShouldBeIgnored) {
   TestData test_data;
   Sketch plain_sketch = CreateEmptyLiquidLegionsSketch();
-  AddRegister(&plain_sketch, /* index = */ 1, /* key = */ 111, /* count = */ 3);
-  AddRegister(&plain_sketch, /* index = */ 2, /* key = */ 201, /* count = */ 4);
-  AddRegister(&plain_sketch, /* index = */ 2, /* key = */ 202, /* count = */ 1);
+  AddRegister(&plain_sketch, /*index=*/1, /*key=*/111, /*count=*/3);
+  AddRegister(&plain_sketch, /*index=*/2, /*key=*/201, /*count=*/4);
+  AddRegister(&plain_sketch, /*index=*/2, /*key=*/202, /*count=*/1);
   std::string encrypted_sketch =
       test_data.EncryptWithFlaggedKey(plain_sketch).value();
 
@@ -770,10 +780,9 @@ TEST(EndToEnd, CrossPublisherDistroyedRegistersShouldBeIgnored) {
 TEST(EndToEnd, SumOfCountsShouldBeCappedbyMaxFrequency) {
   TestData test_data;
   Sketch plain_sketch = CreateEmptyLiquidLegionsSketch();
-  AddRegister(&plain_sketch, /* index = */ 1, /* key = */ 111, /* count = */ 3);
-  AddRegister(&plain_sketch, /* index = */ 2, /* key = */ 222, /* count = */ 5);
-  AddRegister(&plain_sketch, /* index = */ 2, /* key = */ 222,
-              /* count = */ 7);  // 5+7>10
+  AddRegister(&plain_sketch, /*index=*/1, /*key=*/111, /*count=*/3);
+  AddRegister(&plain_sketch, /*index=*/2, /*key=*/222, /*count=*/5);
+  AddRegister(&plain_sketch, /*index=*/2, /*key=*/222, /*count=*/7);  // 5+7>10
   std::string encrypted_sketch =
       test_data.EncryptWithFlaggedKey(plain_sketch).value();
 
@@ -799,19 +808,19 @@ TEST(EndToEnd, ComnbinedCases) {
   // register 7: locally destroyed (key=-1) + normal register, ignored
   //
   // final result should be { 3->1/4, 6->2/4, 11->1/4 }
-  AddRegister(&plain_sketch, /* index = */ 1, /* key = */ 111, /* count = */ 6);
-  AddRegister(&plain_sketch, /* index = */ 2, /* key = */ 222, /* count = */ 3);
-  AddRegister(&plain_sketch, /* index = */ 3, /* key = */ 333, /* count = */ 1);
-  AddRegister(&plain_sketch, /* index = */ 3, /* key = */ 333, /* count = */ 2);
-  AddRegister(&plain_sketch, /* index = */ 3, /* key = */ 333, /* count = */ 3);
-  AddRegister(&plain_sketch, /* index = */ 4, /* key = */ 444, /* count = */ 3);
-  AddRegister(&plain_sketch, /* index = */ 4, /* key = */ 444, /* count = */ 4);
-  AddRegister(&plain_sketch, /* index = */ 4, /* key = */ 444, /* count = */ 5);
-  AddRegister(&plain_sketch, /* index = */ 5, /* key = */ -1, /* count = */ 2);
-  AddRegister(&plain_sketch, /* index = */ 6, /* key = */ 601, /* count = */ 2);
-  AddRegister(&plain_sketch, /* index = */ 6, /* key = */ 602, /* count = */ 2);
-  AddRegister(&plain_sketch, /* index = */ 7, /* key = */ -1, /* count = */ 2);
-  AddRegister(&plain_sketch, /* index = */ 7, /* key = */ 777, /* count = */ 2);
+  AddRegister(&plain_sketch, /*index=*/1, /*key=*/111, /*count=*/6);
+  AddRegister(&plain_sketch, /*index=*/2, /*key=*/222, /*count=*/3);
+  AddRegister(&plain_sketch, /*index=*/3, /*key=*/333, /*count=*/1);
+  AddRegister(&plain_sketch, /*index=*/3, /*key=*/333, /*count=*/2);
+  AddRegister(&plain_sketch, /*index=*/3, /*key=*/333, /*count=*/3);
+  AddRegister(&plain_sketch, /*index=*/4, /*key=*/444, /*count=*/3);
+  AddRegister(&plain_sketch, /*index=*/4, /*key=*/444, /*count=*/4);
+  AddRegister(&plain_sketch, /*index=*/4, /*key=*/444, /*count=*/5);
+  AddRegister(&plain_sketch, /*index=*/5, /*key=*/-1, /*count=*/2);
+  AddRegister(&plain_sketch, /*index=*/6, /*key=*/601, /*count=*/2);
+  AddRegister(&plain_sketch, /*index=*/6, /*key=*/602, /*count=*/2);
+  AddRegister(&plain_sketch, /*index=*/7, /*key=*/-1, /*count=*/2);
+  AddRegister(&plain_sketch, /*index=*/7, /*key=*/777, /*count=*/2);
 
   std::string encrypted_sketch =
       test_data.EncryptWithFlaggedKey(plain_sketch).value();
@@ -839,28 +848,28 @@ TEST(ReachEstimation, NonDpNoiseShouldNotImpactTheResult) {
     AddRegister(&plain_sketch, /*index =*/i, /*key=*/i, /*count=*/1);
   }
 
-  int64_t num = 3;
-  // Set p to ~0, such that the number of reach DP noise is almost a constant,
-  // and thus the result is deterministic.
-  double reach_dp_noise_p = 0.000001;
-  // P for all other noises.
-  double other_p = 0.6;
-  int64_t blinded_histogram_noise_offset = 5;
-  int64_t publisher_noise_offset = 6;
-  int64_t reach_dp_noise_offset = 7;
-  int64_t total_sketch_count = 5;
-  int64_t total_register_count = 200;
+  int publisher_count = 3;
+  int num = 3;
+  // resulted p = 0.716531, offset = 15.
+  // Random blind histogram noise.
+  auto blind_histogram_noise_param = NewDifferentialPrivacyParams(1, 1);
+  // resulted p = 0.716531, offset = 10.
+  // Random noise for publisher noise.
+  auto noise_for_publisher_noise_param = NewDifferentialPrivacyParams(1, 1);
+  // resulted p ~= 0 , offset = 3.
+  // Deterministic reach dp noise.
+  auto reach_dp_noise_param = NewDifferentialPrivacyParams(40, std::exp(-80));
 
   RegisterNoiseGenerationParameters reach_noise_parameters;
   reach_noise_parameters.set_curve_id(kTestCurveId);
-  reach_noise_parameters.set_total_sketches_count(total_sketch_count);
-  reach_noise_parameters.set_total_noise_registers_count(total_register_count);
-  *reach_noise_parameters.mutable_blind_histogram_noise_parameters() =
-      DistributedGeoParams(num, other_p, blinded_histogram_noise_offset);
-  *reach_noise_parameters.mutable_publisher_noise_parameters() =
-      DistributedGeoParams(num, other_p, publisher_noise_offset);
-  *reach_noise_parameters.mutable_global_reach_dp_noise_parameters() =
-      DistributedGeoParams(num, reach_dp_noise_p, reach_dp_noise_offset);
+  reach_noise_parameters.set_total_sketches_count(publisher_count);
+  reach_noise_parameters.set_contributors_count(num);
+  *reach_noise_parameters.mutable_dp_params()->mutable_blind_histogram() =
+      blind_histogram_noise_param;
+  *reach_noise_parameters.mutable_dp_params()
+       ->mutable_noise_for_publisher_noise() = noise_for_publisher_noise_param;
+  *reach_noise_parameters.mutable_dp_params()->mutable_global_reach_dp_noise() =
+      reach_dp_noise_param;
   *reach_noise_parameters.mutable_composite_el_gamal_public_key() =
       test_data.client_el_gamal_public_key_;
 
@@ -889,19 +898,18 @@ TEST(FrequencyNoise, TotalNoiseBytesShouldBeCorrect) {
   public_key.set_generator(public_key_pair.first);
   public_key.set_element(public_key_pair.second);
 
-  int64_t num = 3;
-  double p = 0.6;
-  int64_t non_destroyed_noise_offset = 4;
-  int64_t destroyed_noise_offset = 4;
-  int64_t total_noise_tuple_count = 100;  // should be > 10*4*2+4*2
+  int num = 3;
+  // resulted p = 0.606531, offset = 4
+  auto noise_dp_param = NewDifferentialPrivacyParams(1, 50);
+  int computed_offset = 4;
+
+  int64_t expected_total_noise_tuple_count =
+      (kMaxFrequency + 1) * computed_offset * 2;
 
   FlagCountTupleNoiseGenerationParameters frequency_noise_params;
   frequency_noise_params.set_maximum_frequency(kMaxFrequency);
-  frequency_noise_params.set_total_noise_tuples_count(total_noise_tuple_count);
-  *frequency_noise_params.mutable_non_destroyed_noise_parameters() =
-      DistributedGeoParams(num, p, non_destroyed_noise_offset);
-  *frequency_noise_params.mutable_destroyed_noise_parameters() =
-      DistributedGeoParams(num, p, destroyed_noise_offset);
+  frequency_noise_params.set_contributors_count(num);
+  *frequency_noise_params.mutable_dp_params() = noise_dp_param;
 
   CompleteExecutionPhaseTwoRequest request;
   request.set_curve_id(kTestCurveId);
@@ -914,14 +922,15 @@ TEST(FrequencyNoise, TotalNoiseBytesShouldBeCorrect) {
 
   ASSERT_OK_AND_ASSIGN(CompleteExecutionPhaseTwoResponse Response,
                        CompleteExecutionPhaseTwo(request));
-  ASSERT_THAT(Response.flag_count_tuples(),
-              SizeIs(total_noise_tuple_count * kBytesPerFlagsCountTuple));
+  ASSERT_THAT(
+      Response.flag_count_tuples(),
+      SizeIs(expected_total_noise_tuple_count * kBytesPerFlagsCountTuple));
 
   int frequency_dp_noise_tuples_count = 0;
   int idestroyed_frequency_noise_tuples_count = 0;
   int padding_frequency_noise_tuples_count = 0;
 
-  for (int i = 0; i < total_noise_tuple_count; ++i) {
+  for (int i = 0; i < expected_total_noise_tuple_count; ++i) {
     ASSERT_OK_AND_ASSIGN(
         bool is_frequency_dp_noise_tuples,
         IsFrequencyDpNoiseTuples(
@@ -951,7 +960,7 @@ TEST(FrequencyNoise, TotalNoiseBytesShouldBeCorrect) {
                   is_padding_frequency_noise_tuples,
               1);
   }
-  EXPECT_EQ(total_noise_tuple_count,
+  EXPECT_EQ(expected_total_noise_tuple_count,
             frequency_dp_noise_tuples_count +
                 idestroyed_frequency_noise_tuples_count +
                 padding_frequency_noise_tuples_count);
@@ -970,19 +979,18 @@ TEST(FrequencyNoise, AllFrequencyBucketsShouldHaveNoise) {
   public_key.set_generator(public_key_pair.first);
   public_key.set_element(public_key_pair.second);
 
-  int64_t num = 3;
-  double p = 0.7;
-  int64_t non_destroyed_noise_offset = 10;
-  int64_t destroyed_noise_offset = 5;
-  int64_t total_noise_tuple_count = 220;  // should be > 10*10*2+5*2
+  int num = 3;
+  // resulted p = 0.606531, offset = 12
+  auto noise_dp_param = NewDifferentialPrivacyParams(1, 1);
+  int computed_offset = 12;
+
+  int64_t expected_total_noise_tuple_count =
+      (kMaxFrequency + 1) * computed_offset * 2;
 
   FlagCountTupleNoiseGenerationParameters frequency_noise_params;
   frequency_noise_params.set_maximum_frequency(kMaxFrequency);
-  frequency_noise_params.set_total_noise_tuples_count(total_noise_tuple_count);
-  *frequency_noise_params.mutable_non_destroyed_noise_parameters() =
-      DistributedGeoParams(num, p, non_destroyed_noise_offset);
-  *frequency_noise_params.mutable_destroyed_noise_parameters() =
-      DistributedGeoParams(num, p, destroyed_noise_offset);
+  frequency_noise_params.set_contributors_count(num);
+  *frequency_noise_params.mutable_dp_params() = noise_dp_param;
 
   CompleteExecutionPhaseTwoRequest request;
   request.set_curve_id(kTestCurveId);
@@ -995,14 +1003,15 @@ TEST(FrequencyNoise, AllFrequencyBucketsShouldHaveNoise) {
 
   ASSERT_OK_AND_ASSIGN(CompleteExecutionPhaseTwoResponse Response,
                        CompleteExecutionPhaseTwo(request));
-  ASSERT_THAT(Response.flag_count_tuples(),
-              SizeIs(total_noise_tuple_count * kBytesPerFlagsCountTuple));
+  ASSERT_THAT(
+      Response.flag_count_tuples(),
+      SizeIs(expected_total_noise_tuple_count * kBytesPerFlagsCountTuple));
 
   ASSERT_OK_AND_ASSIGN(std::vector<std::string> count_values_plaintext,
                        GetCountValuesPlaintext(kMaxFrequency, kTestCurveId));
 
   std::array<int, kMaxFrequency> noise_count_per_bucket = {};
-  for (int i = 0; i < total_noise_tuple_count; ++i) {
+  for (int i = 0; i < expected_total_noise_tuple_count; ++i) {
     absl::string_view current_tuples =
         absl::string_view(Response.flag_count_tuples())
             .substr(i * kBytesPerFlagsCountTuple, kBytesPerFlagsCountTuple);
@@ -1035,31 +1044,22 @@ TEST(FrequencyNoise, AllFrequencyBucketsShouldHaveNoise) {
 TEST(FrequencyNoise, DeterministicNoiseShouldHaveNoImpact) {
   TestData test_data;
   Sketch plain_sketch = CreateEmptyLiquidLegionsSketch();
-  AddRegister(&plain_sketch, /* index = */ 1, /* key = */ 111, /* count = */ 2);
-  AddRegister(&plain_sketch, /* index = */ 2, /* key = */ 222, /* count = */ 3);
-  AddRegister(&plain_sketch, /* index = */ 3, /* key = */ 333, /* count = */ 3);
-  AddRegister(&plain_sketch, /* index = */ 4, /* key = */ 444, /* count = */ 3);
+  AddRegister(&plain_sketch, /*index=*/1, /*key=*/111, /*count=*/2);
+  AddRegister(&plain_sketch, /*index=*/2, /*key=*/222, /*count=*/3);
+  AddRegister(&plain_sketch, /*index=*/3, /*key=*/333, /*count=*/3);
+  AddRegister(&plain_sketch, /*index=*/4, /*key=*/444, /*count=*/3);
   std::string encrypted_sketch =
       test_data.EncryptWithFlaggedKey(plain_sketch).value();
 
-  int64_t num = 3;
-  // Set p to ~0, such that the number of frequency DP noise is almost a
-  // constant, and thus the result is deterministic.
-  double frequency_dp_noise_p = 0.000001;
-  // P for all other noises.
-  double other_p = 0.6;
-  int64_t non_destroyed_noise_offset = 5;
-  int64_t destroyed_noise_offset = 6;
-  int64_t total_noise_tuple_count = 200;  // should be > 10*5*2+6*2*2
+  int num = 3;
+  // resulted p ~= 0, offset = 5, such that the number of frequency DP noise is
+  // almost a constant, and thus the result is deterministic.
+  auto noise_dp_param = NewDifferentialPrivacyParams(40, std::exp(-80));
 
   FlagCountTupleNoiseGenerationParameters frequency_noise_params;
   frequency_noise_params.set_maximum_frequency(kMaxFrequency);
-  frequency_noise_params.set_total_noise_tuples_count(total_noise_tuple_count);
-  *frequency_noise_params.mutable_non_destroyed_noise_parameters() =
-      DistributedGeoParams(num, frequency_dp_noise_p,
-                           non_destroyed_noise_offset);
-  *frequency_noise_params.mutable_destroyed_noise_parameters() =
-      DistributedGeoParams(num, other_p, destroyed_noise_offset);
+  frequency_noise_params.set_contributors_count(num);
+  *frequency_noise_params.mutable_dp_params() = noise_dp_param;
 
   ASSERT_OK_AND_ASSIGN(
       MpcResult result,
@@ -1075,26 +1075,21 @@ TEST(FrequencyNoise, DeterministicNoiseShouldHaveNoImpact) {
 TEST(FrequencyNoise, NonDeterministicNoiseShouldRandomizeTheResult) {
   TestData test_data;
   Sketch plain_sketch = CreateEmptyLiquidLegionsSketch();
-  AddRegister(&plain_sketch, /* index = */ 1, /* key = */ 111, /* count = */ 2);
-  AddRegister(&plain_sketch, /* index = */ 2, /* key = */ 222, /* count = */ 3);
-  AddRegister(&plain_sketch, /* index = */ 3, /* key = */ 333, /* count = */ 3);
-  AddRegister(&plain_sketch, /* index = */ 4, /* key = */ 444, /* count = */ 3);
+  AddRegister(&plain_sketch, /*index=*/1, /*key=*/111, /*count=*/2);
+  AddRegister(&plain_sketch, /*index=*/2, /*key=*/222, /*count=*/3);
+  AddRegister(&plain_sketch, /*index=*/3, /*key=*/333, /*count=*/3);
+  AddRegister(&plain_sketch, /*index=*/4, /*key=*/444, /*count=*/3);
   std::string encrypted_sketch =
       test_data.EncryptWithFlaggedKey(plain_sketch).value();
 
-  int64_t num = 3;
-  double p = 0.6;
-  int64_t non_destroyed_noise_offset = 5;
-  int64_t destroyed_noise_offset = 6;
-  int64_t total_noise_tuple_count = 200;  // should be > 10*5*2+6*2*2
+  int num = 3;
+  // resulted p = 0.606531, offset = 12
+  auto noise_dp_param = NewDifferentialPrivacyParams(1, 1);
 
   FlagCountTupleNoiseGenerationParameters frequency_noise_params;
   frequency_noise_params.set_maximum_frequency(kMaxFrequency);
-  frequency_noise_params.set_total_noise_tuples_count(total_noise_tuple_count);
-  *frequency_noise_params.mutable_non_destroyed_noise_parameters() =
-      DistributedGeoParams(num, p, non_destroyed_noise_offset);
-  *frequency_noise_params.mutable_destroyed_noise_parameters() =
-      DistributedGeoParams(num, p, destroyed_noise_offset);
+  frequency_noise_params.set_contributors_count(num);
+  *frequency_noise_params.mutable_dp_params() = noise_dp_param;
 
   ASSERT_OK_AND_ASSIGN(
       MpcResult result,


### PR DESCRIPTION
Major changes:
1. the total_noise_register_count and total_noise_tuple_count are now calculated from the DP parameters, not provided by caller anymore.
2. the noise baselines are also calculated from DP parameters.