### PR TITLE
Renames StorageAbstractions.kt to ComputationsDatabase.kt

### DIFF
--- a/cross-media-measurement/src/main/kotlin/org/wfanet/measurement/duchy/db/computation/ComputationDataClients.kt
+++ b/cross-media-measurement/src/main/kotlin/org/wfanet/measurement/duchy/db/computation/ComputationDataClients.kt
@@ -190,22 +190,4 @@ fun ComputationToken.allOutputBlobMetadataList(): List<ComputationStageBlobMetad
       it.dependencyType == ComputationBlobDependency.PASS_THROUGH
   }
 
-/**
- * Returns the [ComputationStageBlobMetadata] for the output blob that should hold data sent by
- * the [sender].
- *
- * The returned [ComputationStageBlobMetadata] may be for a yet to be written blob. In such a
- * case the path will be empty.
- */
-// TODO: replace with something generic.
-fun ComputationToken.toNoisedSketchBlobMetadataFor(
-  sender: String
-): ComputationStageBlobMetadata {
-  // Get the blob id by looking up the sender in the stage specific details.
-  val stageDetails = stageSpecificDetails.liquidLegionsV1.waitSketchStageDetails
-  val blobId = checkNotNull(stageDetails.externalDuchyLocalBlobIdMap[sender])
-  return blobsList.single {
-    it.dependencyType == ComputationBlobDependency.OUTPUT &&
-      it.blobId == blobId
-  }
-}
+private fun ComputationStageBlobMetadata.toBlobRef() = BlobRef(blobId, path)

--- a/cross-media-measurement/src/main/kotlin/org/wfanet/measurement/duchy/db/computation/testing/FakeComputationsDatabaeTransactor.kt
+++ b/cross-media-measurement/src/main/kotlin/org/wfanet/measurement/duchy/db/computation/testing/FakeComputationsDatabaeTransactor.kt
@@ -20,8 +20,9 @@ import org.wfanet.measurement.duchy.db.computation.BlobRef
 import org.wfanet.measurement.duchy.db.computation.ComputationProtocolStages
 import org.wfanet.measurement.duchy.db.computation.ComputationProtocolStagesEnumHelper
 import org.wfanet.measurement.duchy.db.computation.ComputationStatMetric
-import org.wfanet.measurement.duchy.db.computation.ComputationStorageEditToken
+import org.wfanet.measurement.duchy.db.computation.ComputationsDatabaseTransactor.ComputationEditToken
 import org.wfanet.measurement.duchy.db.computation.ComputationsDatabase
+import org.wfanet.measurement.duchy.db.computation.ComputationsDatabaseTransactor
 import org.wfanet.measurement.duchy.db.computation.EndComputationReason
 import org.wfanet.measurement.duchy.service.internal.computation.newEmptyOutputBlobMetadata
 import org.wfanet.measurement.duchy.service.internal.computation.newInputBlobMetadata
@@ -41,7 +42,7 @@ private const val PRIMARY_WORKER = "PRIMARY_WORKER"
 /**
  * In-memory [ComputationsDatabase]
  */
-class FakeComputationDb private constructor(
+class FakeComputationsDatabaeTransactor private constructor(
   /** Map of local computation ID to [ComputationToken]. */
   private val tokens: MutableMap<Long, ComputationToken>
 ) : Map<Long, ComputationToken> by tokens,
@@ -130,7 +131,7 @@ class FakeComputationDb private constructor(
    *   replace the [tokenToUpdate]. The version of the token is always incremented.
    */
   private fun updateToken(
-    tokenToUpdate: ComputationStorageEditToken<ComputationType, ComputationStage>,
+    tokenToUpdate: ComputationEditToken<ComputationType, ComputationStage>,
     changedTokenBuilderFunc: (ComputationToken) -> ComputationToken.Builder
   ) {
     val current = requireTokenFromCurrent(tokenToUpdate)
@@ -139,7 +140,7 @@ class FakeComputationDb private constructor(
   }
 
   private fun requireTokenFromCurrent(
-    token: ComputationStorageEditToken<ComputationType, ComputationStage>
+    token: ComputationEditToken<ComputationType, ComputationStage>
   ): ComputationToken {
     val current = getNonNull(token.localId)
     // Just the last update time is checked because it mimics the way in which a relational database
@@ -154,7 +155,7 @@ class FakeComputationDb private constructor(
     tokens[globalId] ?: error("No computation for $globalId")
 
   override suspend fun updateComputationStage(
-    token: ComputationStorageEditToken<ComputationType, ComputationStage>,
+    token: ComputationEditToken<ComputationType, ComputationStage>,
     nextStage: ComputationStage,
     inputBlobPaths: List<String>,
     passThroughBlobPaths: List<String>,
@@ -221,7 +222,7 @@ class FakeComputationDb private constructor(
   }
 
   override suspend fun updateComputationDetails(
-    token: ComputationStorageEditToken<ComputationType, ComputationStage>,
+    token: ComputationEditToken<ComputationType, ComputationStage>,
     computationDetails: ComputationDetails
   ) {
     updateToken(token) { existing ->
@@ -230,7 +231,7 @@ class FakeComputationDb private constructor(
   }
 
   override suspend fun endComputation(
-    token: ComputationStorageEditToken<ComputationType, ComputationStage>,
+    token: ComputationEditToken<ComputationType, ComputationStage>,
     endingStage: ComputationStage,
     endComputationReason: EndComputationReason
   ) {
@@ -242,7 +243,7 @@ class FakeComputationDb private constructor(
   }
 
   override suspend fun writeOutputBlobReference(
-    token: ComputationStorageEditToken<ComputationType, ComputationStage>,
+    token: ComputationEditToken<ComputationType, ComputationStage>,
     blobRef: BlobRef
   ) {
     updateToken(token) { existing ->
@@ -262,7 +263,7 @@ class FakeComputationDb private constructor(
   }
 
   override suspend fun enqueue(
-    token: ComputationStorageEditToken<ComputationType, ComputationStage>,
+    token: ComputationEditToken<ComputationType, ComputationStage>,
     delaySecond: Int
   ) {
     // ignore the delaySecond in the fake
@@ -276,7 +277,7 @@ class FakeComputationDb private constructor(
     val claimed = tokens.values.asSequence()
       .filter { it.globalComputationId !in claimedComputationIds }
       .map {
-        ComputationStorageEditToken(
+        ComputationsDatabaseTransactor.ComputationEditToken(
           localId = it.localComputationId,
           protocol = when (it.computationStage.stageCase) {
             ComputationStage.StageCase.LIQUID_LEGIONS_SKETCH_AGGREGATION_V1 ->

--- a/cross-media-measurement/src/main/kotlin/org/wfanet/measurement/duchy/db/computation/testing/FakeComputationsDatabase.kt
+++ b/cross-media-measurement/src/main/kotlin/org/wfanet/measurement/duchy/db/computation/testing/FakeComputationsDatabase.kt
@@ -42,7 +42,7 @@ private const val PRIMARY_WORKER = "PRIMARY_WORKER"
 /**
  * In-memory [ComputationsDatabase]
  */
-class FakeComputationsDatabaeTransactor private constructor(
+class FakeComputationsDatabase private constructor(
   /** Map of local computation ID to [ComputationToken]. */
   private val tokens: MutableMap<Long, ComputationToken>
 ) : Map<Long, ComputationToken> by tokens,

--- a/cross-media-measurement/src/main/kotlin/org/wfanet/measurement/duchy/deploy/gcloud/server/SpannerComputationsServer.kt
+++ b/cross-media-measurement/src/main/kotlin/org/wfanet/measurement/duchy/deploy/gcloud/server/SpannerComputationsServer.kt
@@ -22,8 +22,8 @@ import org.wfanet.measurement.duchy.db.computation.ComputationProtocolStages
 import org.wfanet.measurement.duchy.db.computation.ComputationTypes
 import org.wfanet.measurement.duchy.deploy.common.server.ComputationsServer
 import org.wfanet.measurement.duchy.deploy.gcloud.spanner.computation.ComputationMutations
-import org.wfanet.measurement.duchy.deploy.gcloud.spanner.computation.GcpSpannerComputationsDb
-import org.wfanet.measurement.duchy.deploy.gcloud.spanner.computation.GcpSpannerReadOnlyComputationsRelationalDb
+import org.wfanet.measurement.duchy.deploy.gcloud.spanner.computation.GcpSpannerComputationsDatabaseTransactor
+import org.wfanet.measurement.duchy.deploy.gcloud.spanner.computation.GcpSpannerComputationsDatabaseReader
 import org.wfanet.measurement.gcloud.spanner.SpannerFlags
 import picocli.CommandLine
 
@@ -54,8 +54,8 @@ class SpannerComputationsServer : ComputationsServer() {
     spannerFlags.usingSpanner { spanner ->
       val databaseClient = spanner.databaseClient
       run(
-        GcpSpannerReadOnlyComputationsRelationalDb(databaseClient, protocolStageEnumHelper),
-        GcpSpannerComputationsDb(
+        GcpSpannerComputationsDatabaseReader(databaseClient, protocolStageEnumHelper),
+        GcpSpannerComputationsDatabaseTransactor(
           databaseClient = databaseClient,
           computationMutations = ComputationMutations(
             ComputationTypes, protocolStageEnumHelper, computationProtocolStageDetails

--- a/cross-media-measurement/src/main/kotlin/org/wfanet/measurement/duchy/deploy/gcloud/spanner/computation/GcpSpannerComputationsDatabaseReader.kt
+++ b/cross-media-measurement/src/main/kotlin/org/wfanet/measurement/duchy/deploy/gcloud/spanner/computation/GcpSpannerComputationsDatabaseReader.kt
@@ -20,20 +20,20 @@ import org.wfanet.measurement.common.grpc.grpcRequire
 import org.wfanet.measurement.duchy.db.computation.ComputationProtocolStages
 import org.wfanet.measurement.duchy.db.computation.ComputationProtocolStages.stageToProtocol
 import org.wfanet.measurement.duchy.db.computation.ComputationProtocolStagesEnumHelper
-import org.wfanet.measurement.duchy.db.computation.ReadOnlyComputationsRelationalDb
+import org.wfanet.measurement.duchy.db.computation.ComputationsDatabaseReader
 import org.wfanet.measurement.gcloud.spanner.AsyncDatabaseClient
 import org.wfanet.measurement.internal.duchy.ComputationStage
 import org.wfanet.measurement.internal.duchy.ComputationToken
 import org.wfanet.measurement.internal.duchy.ComputationTypeEnum.ComputationType
 
 /**
- * Implementation of [ReadOnlyComputationsRelationalDb] using GCP Spanner Database.
+ * Implementation of [ComputationsDatabaseReader] using GCP Spanner Database.
  */
-class GcpSpannerReadOnlyComputationsRelationalDb(
+class GcpSpannerComputationsDatabaseReader(
   private val databaseClient: AsyncDatabaseClient,
   private val computationProtocolStagesHelper:
     ComputationProtocolStagesEnumHelper<ComputationType, ComputationStage>
-) : ReadOnlyComputationsRelationalDb {
+) : ComputationsDatabaseReader {
 
   override suspend fun readComputationToken(globalId: String): ComputationToken? =
     ComputationTokenProtoQuery(

--- a/cross-media-measurement/src/main/kotlin/org/wfanet/measurement/duchy/service/internal/computation/ComputationsService.kt
+++ b/cross-media-measurement/src/main/kotlin/org/wfanet/measurement/duchy/service/internal/computation/ComputationsService.kt
@@ -22,7 +22,7 @@ import org.wfanet.measurement.common.grpc.grpcRequire
 import org.wfanet.measurement.common.protoTimestamp
 import org.wfanet.measurement.duchy.db.computation.AfterTransition
 import org.wfanet.measurement.duchy.db.computation.BlobRef
-import org.wfanet.measurement.duchy.db.computation.ComputationStorageEditToken
+import org.wfanet.measurement.duchy.db.computation.ComputationsDatabaseTransactor.ComputationEditToken
 import org.wfanet.measurement.duchy.db.computation.ComputationsDatabase
 import org.wfanet.measurement.duchy.db.computation.EndComputationReason
 import org.wfanet.measurement.duchy.mpcAlgorithm
@@ -253,8 +253,8 @@ class ComputationsService(
 }
 
 private fun ComputationToken.toDatabaseEditToken():
-  ComputationStorageEditToken<ComputationType, ComputationStage> =
-    ComputationStorageEditToken(
+  ComputationEditToken<ComputationType, ComputationStage> =
+    ComputationEditToken(
       localId = localComputationId,
       protocol = computationStage.toComputationType(),
       stage = computationStage,

--- a/cross-media-measurement/src/test/kotlin/org/wfanet/measurement/duchy/daemon/herald/HeraldTest.kt
+++ b/cross-media-measurement/src/test/kotlin/org/wfanet/measurement/duchy/daemon/herald/HeraldTest.kt
@@ -33,7 +33,7 @@ import org.wfanet.measurement.common.DuchyOrder
 import org.wfanet.measurement.common.grpc.testing.GrpcTestServerRule
 import org.wfanet.measurement.common.testing.pollFor
 import org.wfanet.measurement.common.throttler.testing.FakeThrottler
-import org.wfanet.measurement.duchy.db.computation.testing.FakeComputationDb
+import org.wfanet.measurement.duchy.db.computation.testing.FakeComputationsDatabaeTransactor
 import org.wfanet.measurement.duchy.service.internal.computation.ComputationsService
 import org.wfanet.measurement.duchy.service.internal.computation.newEmptyOutputBlobMetadata
 import org.wfanet.measurement.duchy.service.internal.computation.newInputBlobMetadata
@@ -61,7 +61,7 @@ internal class HeraldTest {
     mock(useConstructor = UseConstructor.parameterless()) {}
   private val duchyName = "BOHEMIA"
   private val otherDuchyNames = listOf("SALZBURG", "AUSTRIA")
-  private val fakeComputationStorage = FakeComputationDb()
+  private val fakeComputationStorage = FakeComputationsDatabaeTransactor()
   private val duchyOrder = DuchyOrder(
     setOf(
       Duchy("BOHEMIA", 10L.toBigInteger()),

--- a/cross-media-measurement/src/test/kotlin/org/wfanet/measurement/duchy/daemon/herald/HeraldTest.kt
+++ b/cross-media-measurement/src/test/kotlin/org/wfanet/measurement/duchy/daemon/herald/HeraldTest.kt
@@ -33,7 +33,7 @@ import org.wfanet.measurement.common.DuchyOrder
 import org.wfanet.measurement.common.grpc.testing.GrpcTestServerRule
 import org.wfanet.measurement.common.testing.pollFor
 import org.wfanet.measurement.common.throttler.testing.FakeThrottler
-import org.wfanet.measurement.duchy.db.computation.testing.FakeComputationsDatabaeTransactor
+import org.wfanet.measurement.duchy.db.computation.testing.FakeComputationsDatabase
 import org.wfanet.measurement.duchy.service.internal.computation.ComputationsService
 import org.wfanet.measurement.duchy.service.internal.computation.newEmptyOutputBlobMetadata
 import org.wfanet.measurement.duchy.service.internal.computation.newInputBlobMetadata
@@ -61,7 +61,7 @@ internal class HeraldTest {
     mock(useConstructor = UseConstructor.parameterless()) {}
   private val duchyName = "BOHEMIA"
   private val otherDuchyNames = listOf("SALZBURG", "AUSTRIA")
-  private val fakeComputationStorage = FakeComputationsDatabaeTransactor()
+  private val fakeComputationStorage = FakeComputationsDatabase()
   private val duchyOrder = DuchyOrder(
     setOf(
       Duchy("BOHEMIA", 10L.toBigInteger()),

--- a/cross-media-measurement/src/test/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv1/LiquidLegionsV1MillTest.kt
+++ b/cross-media-measurement/src/test/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv1/LiquidLegionsV1MillTest.kt
@@ -73,7 +73,7 @@ import org.wfanet.measurement.duchy.daemon.mill.CryptoKeySet
 import org.wfanet.measurement.duchy.daemon.mill.toElGamalKeyPair
 import org.wfanet.measurement.duchy.daemon.mill.toElGamalPublicKey
 import org.wfanet.measurement.duchy.db.computation.ComputationDataClients
-import org.wfanet.measurement.duchy.db.computation.testing.FakeComputationsDatabaeTransactor
+import org.wfanet.measurement.duchy.db.computation.testing.FakeComputationsDatabase
 import org.wfanet.measurement.duchy.name
 import org.wfanet.measurement.duchy.service.internal.computation.ComputationsService
 import org.wfanet.measurement.duchy.service.internal.computation.newEmptyOutputBlobMetadata
@@ -128,7 +128,7 @@ class LiquidLegionsV1MillTest {
     mock(useConstructor = UseConstructor.parameterless())
   private val mockCryptoWorker: LiquidLegionsV1Encryption =
     mock(useConstructor = UseConstructor.parameterless())
-  private val fakeComputationDb = FakeComputationsDatabaeTransactor()
+  private val fakeComputationDb = FakeComputationsDatabase()
 
   private lateinit var computationDataClients:
     ComputationDataClients
@@ -519,7 +519,7 @@ class LiquidLegionsV1MillTest {
   @Test
   fun `to add noise using calculated result`() = runBlocking<Unit> {
     // Stage 0. preparing the storage and set up mock
-    val partialToken = FakeComputationsDatabaeTransactor.newPartialToken(
+    val partialToken = FakeComputationsDatabase.newPartialToken(
       localId = LOCAL_ID,
       stage = LiquidLegionsStage.TO_ADD_NOISE.toProtocolStage()
     ).build()
@@ -579,7 +579,7 @@ class LiquidLegionsV1MillTest {
   @Test
   fun `to append sketches and add noise using calculated result`() = runBlocking<Unit> {
     // Stage 0. preparing the storage and set up mock
-    val partialToken = FakeComputationsDatabaeTransactor.newPartialToken(
+    val partialToken = FakeComputationsDatabase.newPartialToken(
       localId = LOCAL_ID,
       stage = LiquidLegionsStage.TO_APPEND_SKETCHES_AND_ADD_NOISE.toProtocolStage()
     ).build()
@@ -644,7 +644,7 @@ class LiquidLegionsV1MillTest {
   @Test
   fun `to blind positions using cached result`() = runBlocking<Unit> {
     // Stage 0. preparing the storage and set up mock
-    val partialToken = FakeComputationsDatabaeTransactor.newPartialToken(
+    val partialToken = FakeComputationsDatabase.newPartialToken(
       localId = LOCAL_ID,
       stage = LiquidLegionsStage.TO_BLIND_POSITIONS.toProtocolStage()
     ).build()
@@ -696,7 +696,7 @@ class LiquidLegionsV1MillTest {
   @Test
   fun `to blind positions using calculated result`() = runBlocking<Unit> {
     // Stage 0. preparing the storage and set up mock
-    val partialToken = FakeComputationsDatabaeTransactor.newPartialToken(
+    val partialToken = FakeComputationsDatabase.newPartialToken(
       localId = LOCAL_ID,
       stage = LiquidLegionsStage.TO_BLIND_POSITIONS.toProtocolStage()
     ).build()
@@ -761,7 +761,7 @@ class LiquidLegionsV1MillTest {
   @Test
   fun `to blind positions and merge register using calculated result`() = runBlocking<Unit> {
     // Stage 0. preparing the storage and set up mock
-    val partialToken = FakeComputationsDatabaeTransactor.newPartialToken(
+    val partialToken = FakeComputationsDatabase.newPartialToken(
       localId = LOCAL_ID,
       stage = LiquidLegionsStage.TO_BLIND_POSITIONS_AND_JOIN_REGISTERS.toProtocolStage()
     ).build()
@@ -827,7 +827,7 @@ class LiquidLegionsV1MillTest {
   @Test
   fun `to decrypt FlagCounts using calculated result`() = runBlocking<Unit> {
     // Stage 0. preparing the storage and set up mock
-    val partialToken = FakeComputationsDatabaeTransactor.newPartialToken(
+    val partialToken = FakeComputationsDatabase.newPartialToken(
       localId = LOCAL_ID,
       stage = LiquidLegionsStage.TO_DECRYPT_FLAG_COUNTS.toProtocolStage()
     ).build()
@@ -882,7 +882,7 @@ class LiquidLegionsV1MillTest {
   @Test
   fun `to decrypt flag count and compute metric`() = runBlocking<Unit> {
     // Stage 0. preparing the storage and set up mock
-    val partialToken = FakeComputationsDatabaeTransactor.newPartialToken(
+    val partialToken = FakeComputationsDatabase.newPartialToken(
       localId = LOCAL_ID,
       stage = LiquidLegionsStage.TO_DECRYPT_FLAG_COUNTS_AND_COMPUTE_METRICS.toProtocolStage()
     ).build()
@@ -952,7 +952,7 @@ class LiquidLegionsV1MillTest {
   @Test
   fun `permanent crypto worker failure, computation should FAIL`() = runBlocking<Unit> {
     // Stage 0. preparing the storage and set up mock
-    val partialToken = FakeComputationsDatabaeTransactor.newPartialToken(
+    val partialToken = FakeComputationsDatabase.newPartialToken(
       localId = LOCAL_ID,
       stage = LiquidLegionsStage.TO_BLIND_POSITIONS.toProtocolStage()
     ).build()
@@ -1021,7 +1021,7 @@ class LiquidLegionsV1MillTest {
   @Test
   fun `trancient grpc failure, result should be cached`() = runBlocking<Unit> {
     // Stage 0. preparing the storage and set up mock
-    val partialToken = FakeComputationsDatabaeTransactor.newPartialToken(
+    val partialToken = FakeComputationsDatabase.newPartialToken(
       localId = LOCAL_ID,
       stage = LiquidLegionsStage.TO_BLIND_POSITIONS.toProtocolStage()
     ).build()

--- a/cross-media-measurement/src/test/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv1/LiquidLegionsV1MillTest.kt
+++ b/cross-media-measurement/src/test/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv1/LiquidLegionsV1MillTest.kt
@@ -73,7 +73,7 @@ import org.wfanet.measurement.duchy.daemon.mill.CryptoKeySet
 import org.wfanet.measurement.duchy.daemon.mill.toElGamalKeyPair
 import org.wfanet.measurement.duchy.daemon.mill.toElGamalPublicKey
 import org.wfanet.measurement.duchy.db.computation.ComputationDataClients
-import org.wfanet.measurement.duchy.db.computation.testing.FakeComputationDb
+import org.wfanet.measurement.duchy.db.computation.testing.FakeComputationsDatabaeTransactor
 import org.wfanet.measurement.duchy.name
 import org.wfanet.measurement.duchy.service.internal.computation.ComputationsService
 import org.wfanet.measurement.duchy.service.internal.computation.newEmptyOutputBlobMetadata
@@ -128,7 +128,7 @@ class LiquidLegionsV1MillTest {
     mock(useConstructor = UseConstructor.parameterless())
   private val mockCryptoWorker: LiquidLegionsV1Encryption =
     mock(useConstructor = UseConstructor.parameterless())
-  private val fakeComputationDb = FakeComputationDb()
+  private val fakeComputationDb = FakeComputationsDatabaeTransactor()
 
   private lateinit var computationDataClients:
     ComputationDataClients
@@ -519,7 +519,7 @@ class LiquidLegionsV1MillTest {
   @Test
   fun `to add noise using calculated result`() = runBlocking<Unit> {
     // Stage 0. preparing the storage and set up mock
-    val partialToken = FakeComputationDb.newPartialToken(
+    val partialToken = FakeComputationsDatabaeTransactor.newPartialToken(
       localId = LOCAL_ID,
       stage = LiquidLegionsStage.TO_ADD_NOISE.toProtocolStage()
     ).build()
@@ -579,7 +579,7 @@ class LiquidLegionsV1MillTest {
   @Test
   fun `to append sketches and add noise using calculated result`() = runBlocking<Unit> {
     // Stage 0. preparing the storage and set up mock
-    val partialToken = FakeComputationDb.newPartialToken(
+    val partialToken = FakeComputationsDatabaeTransactor.newPartialToken(
       localId = LOCAL_ID,
       stage = LiquidLegionsStage.TO_APPEND_SKETCHES_AND_ADD_NOISE.toProtocolStage()
     ).build()
@@ -644,7 +644,7 @@ class LiquidLegionsV1MillTest {
   @Test
   fun `to blind positions using cached result`() = runBlocking<Unit> {
     // Stage 0. preparing the storage and set up mock
-    val partialToken = FakeComputationDb.newPartialToken(
+    val partialToken = FakeComputationsDatabaeTransactor.newPartialToken(
       localId = LOCAL_ID,
       stage = LiquidLegionsStage.TO_BLIND_POSITIONS.toProtocolStage()
     ).build()
@@ -696,7 +696,7 @@ class LiquidLegionsV1MillTest {
   @Test
   fun `to blind positions using calculated result`() = runBlocking<Unit> {
     // Stage 0. preparing the storage and set up mock
-    val partialToken = FakeComputationDb.newPartialToken(
+    val partialToken = FakeComputationsDatabaeTransactor.newPartialToken(
       localId = LOCAL_ID,
       stage = LiquidLegionsStage.TO_BLIND_POSITIONS.toProtocolStage()
     ).build()
@@ -761,7 +761,7 @@ class LiquidLegionsV1MillTest {
   @Test
   fun `to blind positions and merge register using calculated result`() = runBlocking<Unit> {
     // Stage 0. preparing the storage and set up mock
-    val partialToken = FakeComputationDb.newPartialToken(
+    val partialToken = FakeComputationsDatabaeTransactor.newPartialToken(
       localId = LOCAL_ID,
       stage = LiquidLegionsStage.TO_BLIND_POSITIONS_AND_JOIN_REGISTERS.toProtocolStage()
     ).build()
@@ -827,7 +827,7 @@ class LiquidLegionsV1MillTest {
   @Test
   fun `to decrypt FlagCounts using calculated result`() = runBlocking<Unit> {
     // Stage 0. preparing the storage and set up mock
-    val partialToken = FakeComputationDb.newPartialToken(
+    val partialToken = FakeComputationsDatabaeTransactor.newPartialToken(
       localId = LOCAL_ID,
       stage = LiquidLegionsStage.TO_DECRYPT_FLAG_COUNTS.toProtocolStage()
     ).build()
@@ -882,7 +882,7 @@ class LiquidLegionsV1MillTest {
   @Test
   fun `to decrypt flag count and compute metric`() = runBlocking<Unit> {
     // Stage 0. preparing the storage and set up mock
-    val partialToken = FakeComputationDb.newPartialToken(
+    val partialToken = FakeComputationsDatabaeTransactor.newPartialToken(
       localId = LOCAL_ID,
       stage = LiquidLegionsStage.TO_DECRYPT_FLAG_COUNTS_AND_COMPUTE_METRICS.toProtocolStage()
     ).build()
@@ -952,7 +952,7 @@ class LiquidLegionsV1MillTest {
   @Test
   fun `permanent crypto worker failure, computation should FAIL`() = runBlocking<Unit> {
     // Stage 0. preparing the storage and set up mock
-    val partialToken = FakeComputationDb.newPartialToken(
+    val partialToken = FakeComputationsDatabaeTransactor.newPartialToken(
       localId = LOCAL_ID,
       stage = LiquidLegionsStage.TO_BLIND_POSITIONS.toProtocolStage()
     ).build()
@@ -1021,7 +1021,7 @@ class LiquidLegionsV1MillTest {
   @Test
   fun `trancient grpc failure, result should be cached`() = runBlocking<Unit> {
     // Stage 0. preparing the storage and set up mock
-    val partialToken = FakeComputationDb.newPartialToken(
+    val partialToken = FakeComputationsDatabaeTransactor.newPartialToken(
       localId = LOCAL_ID,
       stage = LiquidLegionsStage.TO_BLIND_POSITIONS.toProtocolStage()
     ).build()

--- a/cross-media-measurement/src/test/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv2/LiquidLegionsV2MillTest.kt
+++ b/cross-media-measurement/src/test/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv2/LiquidLegionsV2MillTest.kt
@@ -76,7 +76,7 @@ import org.wfanet.measurement.duchy.daemon.mill.CryptoKeySet
 import org.wfanet.measurement.duchy.daemon.mill.toElGamalKeyPair
 import org.wfanet.measurement.duchy.daemon.mill.toElGamalPublicKey
 import org.wfanet.measurement.duchy.db.computation.ComputationDataClients
-import org.wfanet.measurement.duchy.db.computation.testing.FakeComputationDb
+import org.wfanet.measurement.duchy.db.computation.testing.FakeComputationsDatabaeTransactor
 import org.wfanet.measurement.duchy.name
 import org.wfanet.measurement.duchy.service.internal.computation.ComputationsService
 import org.wfanet.measurement.duchy.service.internal.computation.newEmptyOutputBlobMetadata
@@ -145,7 +145,7 @@ class LiquidLegionsV2MillTest {
     mock(useConstructor = UseConstructor.parameterless())
   private val mockCryptoWorker: LiquidLegionsV2Encryption =
     mock(useConstructor = UseConstructor.parameterless())
-  private val fakeComputationDb = FakeComputationDb()
+  private val fakeComputationDb = FakeComputationsDatabaeTransactor()
 
   private lateinit var computationDataClients:
     ComputationDataClients
@@ -553,7 +553,7 @@ class LiquidLegionsV2MillTest {
   @Test
   fun `setup phase at non-aggregator using calculated result`() = runBlocking<Unit> {
     // Stage 0. preparing the storage and set up mock
-    val partialToken = FakeComputationDb.newPartialToken(
+    val partialToken = FakeComputationsDatabaeTransactor.newPartialToken(
       localId = LOCAL_ID,
       stage = SETUP_PHASE.toProtocolStage()
     ).build()
@@ -618,7 +618,7 @@ class LiquidLegionsV2MillTest {
   @Test
   fun `setup phase at aggregator using calculated result`() = runBlocking<Unit> {
     // Stage 0. preparing the storage and set up mock
-    val partialToken = FakeComputationDb.newPartialToken(
+    val partialToken = FakeComputationsDatabaeTransactor.newPartialToken(
       localId = LOCAL_ID,
       stage = SETUP_PHASE.toProtocolStage()
     ).build()
@@ -687,7 +687,7 @@ class LiquidLegionsV2MillTest {
   @Test
   fun `execution phase one at non-aggregater using cached result`() = runBlocking<Unit> {
     // Stage 0. preparing the storage and set up mock
-    val partialToken = FakeComputationDb.newPartialToken(
+    val partialToken = FakeComputationsDatabaeTransactor.newPartialToken(
       localId = LOCAL_ID,
       stage = EXECUTION_PHASE_ONE.toProtocolStage()
     ).build()
@@ -739,7 +739,7 @@ class LiquidLegionsV2MillTest {
   @Test
   fun `execution phase one at non-aggregater using calculated result`() = runBlocking<Unit> {
     // Stage 0. preparing the storage and set up mock
-    val partialToken = FakeComputationDb.newPartialToken(
+    val partialToken = FakeComputationsDatabaeTransactor.newPartialToken(
       localId = LOCAL_ID,
       stage = EXECUTION_PHASE_ONE.toProtocolStage()
     ).build()
@@ -804,7 +804,7 @@ class LiquidLegionsV2MillTest {
   @Test
   fun `execution phase one at aggregater using calculated result`() = runBlocking<Unit> {
     // Stage 0. preparing the storage and set up mock
-    val partialToken = FakeComputationDb.newPartialToken(
+    val partialToken = FakeComputationsDatabaeTransactor.newPartialToken(
       localId = LOCAL_ID,
       stage = EXECUTION_PHASE_ONE.toProtocolStage()
     ).build()
@@ -870,7 +870,7 @@ class LiquidLegionsV2MillTest {
   @Test
   fun `execution phase two at non-aggregater using calculated result`() = runBlocking<Unit> {
     // Stage 0. preparing the storage and set up mock
-    val partialToken = FakeComputationDb.newPartialToken(
+    val partialToken = FakeComputationsDatabaeTransactor.newPartialToken(
       localId = LOCAL_ID,
       stage = EXECUTION_PHASE_TWO.toProtocolStage()
     ).build()
@@ -935,7 +935,7 @@ class LiquidLegionsV2MillTest {
   @Test
   fun `execution phase two at aggregater using calculated result`() = runBlocking<Unit> {
     // Stage 0. preparing the storage and set up mock
-    val partialToken = FakeComputationDb.newPartialToken(
+    val partialToken = FakeComputationsDatabaeTransactor.newPartialToken(
       localId = LOCAL_ID,
       stage = EXECUTION_PHASE_TWO.toProtocolStage()
     ).build()
@@ -1008,7 +1008,7 @@ class LiquidLegionsV2MillTest {
   fun `execution phase three at non-aggregater using calculated result`() =
     runBlocking<Unit> {
       // Stage 0. preparing the storage and set up mock
-      val partialToken = FakeComputationDb.newPartialToken(
+      val partialToken = FakeComputationsDatabaeTransactor.newPartialToken(
         localId = LOCAL_ID,
         stage = EXECUTION_PHASE_THREE.toProtocolStage()
       ).build()
@@ -1063,7 +1063,7 @@ class LiquidLegionsV2MillTest {
   @Test
   fun `execution phase three at aggregater using calculated result`() = runBlocking<Unit> {
     // Stage 0. preparing the storage and set up mock
-    val partialToken = FakeComputationDb.newPartialToken(
+    val partialToken = FakeComputationsDatabaeTransactor.newPartialToken(
       localId = LOCAL_ID,
       stage = EXECUTION_PHASE_THREE.toProtocolStage()
     ).build()

--- a/cross-media-measurement/src/test/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv2/LiquidLegionsV2MillTest.kt
+++ b/cross-media-measurement/src/test/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv2/LiquidLegionsV2MillTest.kt
@@ -76,7 +76,7 @@ import org.wfanet.measurement.duchy.daemon.mill.CryptoKeySet
 import org.wfanet.measurement.duchy.daemon.mill.toElGamalKeyPair
 import org.wfanet.measurement.duchy.daemon.mill.toElGamalPublicKey
 import org.wfanet.measurement.duchy.db.computation.ComputationDataClients
-import org.wfanet.measurement.duchy.db.computation.testing.FakeComputationsDatabaeTransactor
+import org.wfanet.measurement.duchy.db.computation.testing.FakeComputationsDatabase
 import org.wfanet.measurement.duchy.name
 import org.wfanet.measurement.duchy.service.internal.computation.ComputationsService
 import org.wfanet.measurement.duchy.service.internal.computation.newEmptyOutputBlobMetadata
@@ -145,7 +145,7 @@ class LiquidLegionsV2MillTest {
     mock(useConstructor = UseConstructor.parameterless())
   private val mockCryptoWorker: LiquidLegionsV2Encryption =
     mock(useConstructor = UseConstructor.parameterless())
-  private val fakeComputationDb = FakeComputationsDatabaeTransactor()
+  private val fakeComputationDb = FakeComputationsDatabase()
 
   private lateinit var computationDataClients:
     ComputationDataClients
@@ -553,7 +553,7 @@ class LiquidLegionsV2MillTest {
   @Test
   fun `setup phase at non-aggregator using calculated result`() = runBlocking<Unit> {
     // Stage 0. preparing the storage and set up mock
-    val partialToken = FakeComputationsDatabaeTransactor.newPartialToken(
+    val partialToken = FakeComputationsDatabase.newPartialToken(
       localId = LOCAL_ID,
       stage = SETUP_PHASE.toProtocolStage()
     ).build()
@@ -618,7 +618,7 @@ class LiquidLegionsV2MillTest {
   @Test
   fun `setup phase at aggregator using calculated result`() = runBlocking<Unit> {
     // Stage 0. preparing the storage and set up mock
-    val partialToken = FakeComputationsDatabaeTransactor.newPartialToken(
+    val partialToken = FakeComputationsDatabase.newPartialToken(
       localId = LOCAL_ID,
       stage = SETUP_PHASE.toProtocolStage()
     ).build()
@@ -687,7 +687,7 @@ class LiquidLegionsV2MillTest {
   @Test
   fun `execution phase one at non-aggregater using cached result`() = runBlocking<Unit> {
     // Stage 0. preparing the storage and set up mock
-    val partialToken = FakeComputationsDatabaeTransactor.newPartialToken(
+    val partialToken = FakeComputationsDatabase.newPartialToken(
       localId = LOCAL_ID,
       stage = EXECUTION_PHASE_ONE.toProtocolStage()
     ).build()
@@ -739,7 +739,7 @@ class LiquidLegionsV2MillTest {
   @Test
   fun `execution phase one at non-aggregater using calculated result`() = runBlocking<Unit> {
     // Stage 0. preparing the storage and set up mock
-    val partialToken = FakeComputationsDatabaeTransactor.newPartialToken(
+    val partialToken = FakeComputationsDatabase.newPartialToken(
       localId = LOCAL_ID,
       stage = EXECUTION_PHASE_ONE.toProtocolStage()
     ).build()
@@ -804,7 +804,7 @@ class LiquidLegionsV2MillTest {
   @Test
   fun `execution phase one at aggregater using calculated result`() = runBlocking<Unit> {
     // Stage 0. preparing the storage and set up mock
-    val partialToken = FakeComputationsDatabaeTransactor.newPartialToken(
+    val partialToken = FakeComputationsDatabase.newPartialToken(
       localId = LOCAL_ID,
       stage = EXECUTION_PHASE_ONE.toProtocolStage()
     ).build()
@@ -870,7 +870,7 @@ class LiquidLegionsV2MillTest {
   @Test
   fun `execution phase two at non-aggregater using calculated result`() = runBlocking<Unit> {
     // Stage 0. preparing the storage and set up mock
-    val partialToken = FakeComputationsDatabaeTransactor.newPartialToken(
+    val partialToken = FakeComputationsDatabase.newPartialToken(
       localId = LOCAL_ID,
       stage = EXECUTION_PHASE_TWO.toProtocolStage()
     ).build()
@@ -935,7 +935,7 @@ class LiquidLegionsV2MillTest {
   @Test
   fun `execution phase two at aggregater using calculated result`() = runBlocking<Unit> {
     // Stage 0. preparing the storage and set up mock
-    val partialToken = FakeComputationsDatabaeTransactor.newPartialToken(
+    val partialToken = FakeComputationsDatabase.newPartialToken(
       localId = LOCAL_ID,
       stage = EXECUTION_PHASE_TWO.toProtocolStage()
     ).build()
@@ -1008,7 +1008,7 @@ class LiquidLegionsV2MillTest {
   fun `execution phase three at non-aggregater using calculated result`() =
     runBlocking<Unit> {
       // Stage 0. preparing the storage and set up mock
-      val partialToken = FakeComputationsDatabaeTransactor.newPartialToken(
+      val partialToken = FakeComputationsDatabase.newPartialToken(
         localId = LOCAL_ID,
         stage = EXECUTION_PHASE_THREE.toProtocolStage()
       ).build()
@@ -1063,7 +1063,7 @@ class LiquidLegionsV2MillTest {
   @Test
   fun `execution phase three at aggregater using calculated result`() = runBlocking<Unit> {
     // Stage 0. preparing the storage and set up mock
-    val partialToken = FakeComputationsDatabaeTransactor.newPartialToken(
+    val partialToken = FakeComputationsDatabase.newPartialToken(
       localId = LOCAL_ID,
       stage = EXECUTION_PHASE_THREE.toProtocolStage()
     ).build()

--- a/cross-media-measurement/src/test/kotlin/org/wfanet/measurement/duchy/db/computation/ComputationDataClientsTest.kt
+++ b/cross-media-measurement/src/test/kotlin/org/wfanet/measurement/duchy/db/computation/ComputationDataClientsTest.kt
@@ -33,7 +33,7 @@ import org.wfanet.measurement.common.grpc.testing.GrpcTestServerRule
 import org.wfanet.measurement.common.testing.TestClockWithNamedInstants
 import org.wfanet.measurement.common.withPadding
 import org.wfanet.measurement.duchy.DuchyPublicKeyMap
-import org.wfanet.measurement.duchy.db.computation.testing.FakeComputationDb
+import org.wfanet.measurement.duchy.db.computation.testing.FakeComputationsDatabaeTransactor
 import org.wfanet.measurement.duchy.service.internal.computation.ComputationsService
 import org.wfanet.measurement.duchy.service.internal.computation.newEmptyOutputBlobMetadata
 import org.wfanet.measurement.duchy.service.internal.computation.toGetTokenRequest
@@ -88,7 +88,7 @@ val duchyOrder = DuchyOrder(
 
 @RunWith(JUnit4::class)
 class ComputationDataClientsTest {
-  private val fakeDatabase = FakeComputationDb()
+  private val fakeDatabase = FakeComputationsDatabaeTransactor()
 
   @get:Rule
   val grpcTestServerRule = GrpcTestServerRule {

--- a/cross-media-measurement/src/test/kotlin/org/wfanet/measurement/duchy/db/computation/ComputationDataClientsTest.kt
+++ b/cross-media-measurement/src/test/kotlin/org/wfanet/measurement/duchy/db/computation/ComputationDataClientsTest.kt
@@ -33,7 +33,7 @@ import org.wfanet.measurement.common.grpc.testing.GrpcTestServerRule
 import org.wfanet.measurement.common.testing.TestClockWithNamedInstants
 import org.wfanet.measurement.common.withPadding
 import org.wfanet.measurement.duchy.DuchyPublicKeyMap
-import org.wfanet.measurement.duchy.db.computation.testing.FakeComputationsDatabaeTransactor
+import org.wfanet.measurement.duchy.db.computation.testing.FakeComputationsDatabase
 import org.wfanet.measurement.duchy.service.internal.computation.ComputationsService
 import org.wfanet.measurement.duchy.service.internal.computation.newEmptyOutputBlobMetadata
 import org.wfanet.measurement.duchy.service.internal.computation.toGetTokenRequest
@@ -88,7 +88,7 @@ val duchyOrder = DuchyOrder(
 
 @RunWith(JUnit4::class)
 class ComputationDataClientsTest {
-  private val fakeDatabase = FakeComputationsDatabaeTransactor()
+  private val fakeDatabase = FakeComputationsDatabase()
 
   @get:Rule
   val grpcTestServerRule = GrpcTestServerRule {

--- a/cross-media-measurement/src/test/kotlin/org/wfanet/measurement/duchy/deploy/gcloud/spanner/computation/BUILD.bazel
+++ b/cross-media-measurement/src/test/kotlin/org/wfanet/measurement/duchy/deploy/gcloud/spanner/computation/BUILD.bazel
@@ -40,8 +40,8 @@ spanner_emulator_test(
 
 spanner_emulator_test(
     name = "GcpSpannerComputationDbTest",
-    srcs = ["GcpSpannerComputationsDbTest.kt"],
-    test_class = "org.wfanet.measurement.duchy.deploy.gcloud.spanner.computation.GcpSpannerComputationsDbTest",
+    srcs = ["GcpSpannerComputationsDatabaseTransactorTest.kt"],
+    test_class = "org.wfanet.measurement.duchy.deploy.gcloud.spanner.computation.GcpSpannerComputationsDatabaseTransactorTest",
     deps = [
         ":fake_protocol_stage_details_java_proto",
         "//imports/java/com/google/cloud/spanner",
@@ -57,8 +57,8 @@ spanner_emulator_test(
 
 spanner_emulator_test(
     name = "GcpSpannerReadOnlyComputationsRelationalDbTest",
-    srcs = ["GcpSpannerReadOnlyComputationsRelationalDbTest.kt"],
-    test_class = "org.wfanet.measurement.duchy.deploy.gcloud.spanner.computation.GcpSpannerReadOnlyComputationsRelationalDbTest",
+    srcs = ["GcpSpannerComputationsDatabaseReaderTest.kt"],
+    test_class = "org.wfanet.measurement.duchy.deploy.gcloud.spanner.computation.GcpSpannerComputationsDatabaseReaderTest",
     deps = [
         "//imports/java/com/google/cloud/spanner",
         "//imports/java/com/google/common/truth/extensions/proto",

--- a/cross-media-measurement/src/test/kotlin/org/wfanet/measurement/duchy/deploy/gcloud/spanner/computation/GcpSpannerComputationsDatabaseReaderTest.kt
+++ b/cross-media-measurement/src/test/kotlin/org/wfanet/measurement/duchy/deploy/gcloud/spanner/computation/GcpSpannerComputationsDatabaseReaderTest.kt
@@ -40,7 +40,7 @@ import org.wfanet.measurement.internal.duchy.ComputationTypeEnum.ComputationType
 import org.wfanet.measurement.protocol.LiquidLegionsSketchAggregationV1
 
 @RunWith(JUnit4::class)
-class GcpSpannerReadOnlyComputationsRelationalDbTest :
+class GcpSpannerComputationsDatabaseReaderTest :
   UsingSpannerEmulator(COMPUTATIONS_SCHEMA) {
 
   companion object {
@@ -70,12 +70,12 @@ class GcpSpannerReadOnlyComputationsRelationalDbTest :
     )
 
   private lateinit var liquidLegionsSketchAggregationSpannerReader:
-    GcpSpannerReadOnlyComputationsRelationalDb
+    GcpSpannerComputationsDatabaseReader
 
   @Before
   fun initDatabase() {
     liquidLegionsSketchAggregationSpannerReader =
-      GcpSpannerReadOnlyComputationsRelationalDb(
+      GcpSpannerComputationsDatabaseReader(
         databaseClient,
         ComputationProtocolStages
       )

--- a/cross-media-measurement/src/test/kotlin/org/wfanet/measurement/duchy/service/internal/computation/ComputationsServiceTest.kt
+++ b/cross-media-measurement/src/test/kotlin/org/wfanet/measurement/duchy/service/internal/computation/ComputationsServiceTest.kt
@@ -27,7 +27,7 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.wfanet.measurement.common.grpc.testing.GrpcTestServerRule
 import org.wfanet.measurement.common.testing.verifyProtoArgument
-import org.wfanet.measurement.duchy.db.computation.testing.FakeComputationDb
+import org.wfanet.measurement.duchy.db.computation.testing.FakeComputationsDatabaeTransactor
 import org.wfanet.measurement.duchy.toProtocolStage
 import org.wfanet.measurement.internal.duchy.AdvanceComputationStageRequest
 import org.wfanet.measurement.internal.duchy.ClaimWorkRequest
@@ -79,7 +79,7 @@ class ComputationsServiceTest {
     }.build()
   }
 
-  private val fakeDatabase = FakeComputationDb()
+  private val fakeDatabase = FakeComputationsDatabaeTransactor()
   private val mockGlobalComputations: GlobalComputationsCoroutineImplBase =
     mock(useConstructor = UseConstructor.parameterless())
 

--- a/cross-media-measurement/src/test/kotlin/org/wfanet/measurement/duchy/service/internal/computation/ComputationsServiceTest.kt
+++ b/cross-media-measurement/src/test/kotlin/org/wfanet/measurement/duchy/service/internal/computation/ComputationsServiceTest.kt
@@ -27,7 +27,7 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.wfanet.measurement.common.grpc.testing.GrpcTestServerRule
 import org.wfanet.measurement.common.testing.verifyProtoArgument
-import org.wfanet.measurement.duchy.db.computation.testing.FakeComputationsDatabaeTransactor
+import org.wfanet.measurement.duchy.db.computation.testing.FakeComputationsDatabase
 import org.wfanet.measurement.duchy.toProtocolStage
 import org.wfanet.measurement.internal.duchy.AdvanceComputationStageRequest
 import org.wfanet.measurement.internal.duchy.ClaimWorkRequest
@@ -79,7 +79,7 @@ class ComputationsServiceTest {
     }.build()
   }
 
-  private val fakeDatabase = FakeComputationsDatabaeTransactor()
+  private val fakeDatabase = FakeComputationsDatabase()
   private val mockGlobalComputations: GlobalComputationsCoroutineImplBase =
     mock(useConstructor = UseConstructor.parameterless())
 

--- a/cross-media-measurement/src/test/kotlin/org/wfanet/measurement/duchy/service/internal/computationstats/ComputationStatsServiceTest.kt
+++ b/cross-media-measurement/src/test/kotlin/org/wfanet/measurement/duchy/service/internal/computationstats/ComputationStatsServiceTest.kt
@@ -23,14 +23,14 @@ import kotlinx.coroutines.runBlocking
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
-import org.wfanet.measurement.duchy.db.computation.testing.FakeComputationsDatabaeTransactor
+import org.wfanet.measurement.duchy.db.computation.testing.FakeComputationsDatabase
 import org.wfanet.measurement.internal.duchy.ComputationStage
 import org.wfanet.measurement.internal.duchy.CreateComputationStatRequest
 import org.wfanet.measurement.internal.duchy.CreateComputationStatResponse
 
 @RunWith(JUnit4::class)
 class ComputationStatsServiceTest {
-  private val fakeDatabase = FakeComputationsDatabaeTransactor()
+  private val fakeDatabase = FakeComputationsDatabase()
   private val service: ComputationStatsService
 
   init {

--- a/cross-media-measurement/src/test/kotlin/org/wfanet/measurement/duchy/service/internal/computationstats/ComputationStatsServiceTest.kt
+++ b/cross-media-measurement/src/test/kotlin/org/wfanet/measurement/duchy/service/internal/computationstats/ComputationStatsServiceTest.kt
@@ -23,14 +23,14 @@ import kotlinx.coroutines.runBlocking
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
-import org.wfanet.measurement.duchy.db.computation.testing.FakeComputationDb
+import org.wfanet.measurement.duchy.db.computation.testing.FakeComputationsDatabaeTransactor
 import org.wfanet.measurement.internal.duchy.ComputationStage
 import org.wfanet.measurement.internal.duchy.CreateComputationStatRequest
 import org.wfanet.measurement.internal.duchy.CreateComputationStatResponse
 
 @RunWith(JUnit4::class)
 class ComputationStatsServiceTest {
-  private val fakeDatabase = FakeComputationDb()
+  private val fakeDatabase = FakeComputationsDatabaeTransactor()
   private val service: ComputationStatsService
 
   init {


### PR DESCRIPTION
The naming of and in this file are from a time when we refered to
relational database storage and BLOb sotrage. The terminology changed
to Database means relational and Storage is for BLObs, but the classes
here did not fully adopt that convention.

ComputationsDatabase is the main interface of interest in the file
so the file is named after it.

ComputationsRelationalDb was renamed to ComputationsDatabaseTransactor.
This change is to highlight that the interface performs transactional
read/write operations to the computations database. It also was done
to better distinguish it from the ComputationsDatabase which is
the grouping of an interface for read-only operations and an
interface for read/write transactions.

The ReadOnlyComputationsRelationalDb interface was renamed to
ComputationsDatabaseReader.

The ComputationStorageEditToken was moved to a be a child class of
ComputationsDatabaseTransactor. It is only ever used in that context.
It was also renamed to ComputationEditToken.