### PR TITLE
Add a method in the LLV2 mill to get partially combined public key.

### DIFF
--- a/cross-media-measurement/src/main/kotlin/org/wfanet/measurement/duchy/daemon/mill/CryptoKeySet.kt
+++ b/cross-media-measurement/src/main/kotlin/org/wfanet/measurement/duchy/daemon/mill/CryptoKeySet.kt
@@ -24,7 +24,7 @@ import org.wfanet.measurement.common.hexAsByteString
 data class CryptoKeySet(
   // The public and private ElGamal keys of the duchy that owns the mill.
   val ownPublicAndPrivateKeys: ElGamalKeyPair,
-  // A map from other duchies' name and their public ElGamal keys.
+  // A map of other duchies' name and their public ElGamal keys.
   val otherDuchyPublicKeys: Map<String, ElGamalPublicKey>,
   // The client ElGamal public keys combined from all duchies' public keys.
   val clientPublicKey: ElGamalPublicKey,
@@ -39,7 +39,7 @@ const val BYTES_OF_EL_GAMAL_PUBLIC_KEYS = BYTES_PER_PUBLIC_KEY * 2
 const val BYTES_OF_EL_GAMAL_KEYS = BYTES_OF_EL_GAMAL_PUBLIC_KEYS + BYTES_PER_PRIVATE_KEY
 
 /**
- * Convert a hexString to its equivalent ElGamalKeyPair proto object.
+ * Converts a hexString to its equivalent ElGamalKeyPair proto object.
  */
 fun String.toElGamalKeyPair(): ElGamalKeyPair {
   require(length == BYTES_OF_EL_GAMAL_KEYS * 2) {
@@ -52,7 +52,7 @@ fun String.toElGamalKeyPair(): ElGamalKeyPair {
 }
 
 /**
- * Convert a hexString to its equivalent ElGamalPublicKey proto object.
+ * Converts a hexString to its equivalent ElGamalPublicKey proto object.
  */
 fun String.toElGamalPublicKey(): ElGamalPublicKey {
   require(length == BYTES_OF_EL_GAMAL_PUBLIC_KEYS * 2) {

--- a/cross-media-measurement/src/main/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv2/BUILD.bazel
+++ b/cross-media-measurement/src/main/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv2/BUILD.bazel
@@ -33,6 +33,8 @@ kt_jvm_library(
         "//src/main/proto/wfa/measurement/system/v1alpha:computation_control_service_kt_jvm_grpc",
         "//src/main/proto/wfa/measurement/system/v1alpha:global_computation_service_kt_jvm_grpc",
         "//src/main/swig/common/crypto/liquidlegionsv2:liquid_legions_v2_encryption_utility",
+        "@any_sketch_java//src/main/java/org/wfanet/anysketch/crypto:sketch_encrypter_adapter",
         "@any_sketch_java//src/main/java/org/wfanet/estimation:estimators",
+        "@any_sketch_java//src/main/proto/wfa/any_sketch/crypto:sketch_encryption_methods_java_proto",
     ],
 )

--- a/cross-media-measurement/src/main/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv2/LiquidLegionsV2Mill.kt
+++ b/cross-media-measurement/src/main/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv2/LiquidLegionsV2Mill.kt
@@ -18,6 +18,11 @@ import java.nio.file.Paths
 import java.time.Clock
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.flattenConcat
+import org.wfanet.anysketch.crypto.CombineElGamalPublicKeysRequest
+import org.wfanet.anysketch.crypto.CombineElGamalPublicKeysResponse
+import org.wfanet.anysketch.crypto.ElGamalPublicKeys
+import org.wfanet.anysketch.crypto.SketchEncrypterAdapter
+import org.wfanet.measurement.common.DuchyOrder
 import org.wfanet.measurement.common.crypto.CompleteExecutionPhaseOneAtAggregatorRequest
 import org.wfanet.measurement.common.crypto.CompleteExecutionPhaseOneAtAggregatorResponse
 import org.wfanet.measurement.common.crypto.CompleteExecutionPhaseOneRequest
@@ -32,6 +37,7 @@ import org.wfanet.measurement.common.crypto.CompleteExecutionPhaseTwoRequest
 import org.wfanet.measurement.common.crypto.CompleteExecutionPhaseTwoResponse
 import org.wfanet.measurement.common.crypto.CompleteSetupPhaseRequest
 import org.wfanet.measurement.common.crypto.CompleteSetupPhaseResponse
+import org.wfanet.measurement.common.crypto.ElGamalPublicKey
 import org.wfanet.measurement.common.crypto.liquidlegionsv2.LiquidLegionsV2Encryption
 import org.wfanet.measurement.common.flatten
 import org.wfanet.measurement.common.loadLibrary
@@ -78,6 +84,7 @@ import org.wfanet.measurement.system.v1alpha.LiquidLegionsV2
  * @param workerStubs A map from other duchies' Ids to their corresponding
  *    computationControlClients, used for passing computation to other duchies.
  * @param cryptoKeySet The set of crypto keys used in the computation.
+ * @param duchyOrder The DuchyOrder that determines ordering of duchies for computations.
  * @param cryptoWorker The cryptoWorker that performs the actual computation.
  * @param liquidLegionsConfig The configuration of the LiquidLegions sketch.
  */
@@ -90,8 +97,10 @@ class LiquidLegionsV2Mill(
   throttler: MinimumIntervalThrottler,
   requestChunkSizeBytes: Int = 1024 * 32, // 32 KiB
   clock: Clock = Clock.systemUTC(),
+
   private val workerStubs: Map<String, ComputationControlCoroutineStub>,
   private val cryptoKeySet: CryptoKeySet,
+  private val duchyOrder: DuchyOrder,
   private val cryptoWorker: LiquidLegionsV2Encryption,
   private val liquidLegionsConfig: LiquidLegionsConfig = LiquidLegionsConfig(
     12.0,
@@ -516,11 +525,50 @@ class LiquidLegionsV2Mill(
       )
   }
 
+  // Combines the public keys from the duchies after this duchy in the ring and the primary duchy.
+  fun getPartiallyCombinedPublicKey(globalId: String, nextDuchy: String): ElGamalPublicKey {
+    val order = duchyOrder.computationOrder(globalId)
+    require(order.contains(nextDuchy)) { "$nextDuchy doesn't exist in the duchy ring." }
+    if (nextDuchy == order[0]) {
+      // Return the aggregator's key if next duchy is the aggregator.
+      return cryptoKeySet.otherDuchyPublicKeys[nextDuchy] ?: error(
+        "$nextDuchy is not in the key set."
+      )
+    }
+
+    val partialList = order.subList(order.indexOf(nextDuchy), order.size) + order[0]
+    val request = CombineElGamalPublicKeysRequest.newBuilder().apply {
+      curveId = cryptoKeySet.curveId.toLong()
+      addAllElGamalKeys(
+        partialList.map {
+          val key = cryptoKeySet.otherDuchyPublicKeys[it] ?: error(
+            "$it is not in the key set."
+          )
+          ElGamalPublicKeys.newBuilder().apply {
+            elGamalG = key.generator
+            elGamalY = key.element
+          }.build()
+        }
+      )
+    }.build()
+    val response = CombineElGamalPublicKeysResponse.parseFrom(
+      SketchEncrypterAdapter.CombineElGamalPublicKeys(request.toByteArray())
+    )
+    return ElGamalPublicKey.newBuilder().apply {
+      generator = response.elGamalKeys.elGamalG
+      element = response.elGamalKeys.elGamalY
+    }.build()
+  }
+
   companion object {
     init {
       loadLibrary(
         name = "estimators",
         directoryPath = Paths.get("any_sketch_java/src/main/java/org/wfanet/estimation")
+      )
+      loadLibrary(
+        name = "sketch_encrypter_adapter",
+        directoryPath = Paths.get("any_sketch_java/src/main/java/org/wfanet/anysketch/crypto")
       )
     }
   }

--- a/cross-media-measurement/src/main/kotlin/org/wfanet/measurement/duchy/deploy/common/daemon/mill/liquidlegionsv2/LiquidLegionsV2MillDaemon.kt
+++ b/cross-media-measurement/src/main/kotlin/org/wfanet/measurement/duchy/deploy/common/daemon/mill/liquidlegionsv2/LiquidLegionsV2MillDaemon.kt
@@ -28,6 +28,7 @@ import org.wfanet.measurement.duchy.daemon.mill.CryptoKeySet
 import org.wfanet.measurement.duchy.daemon.mill.LiquidLegionsConfig
 import org.wfanet.measurement.duchy.daemon.mill.liquidlegionsv2.LiquidLegionsV2Mill
 import org.wfanet.measurement.duchy.db.computation.ComputationDataClients
+import org.wfanet.measurement.duchy.toDuchyOrder
 import org.wfanet.measurement.internal.duchy.ComputationStatsGrpcKt.ComputationStatsCoroutineStub
 import org.wfanet.measurement.internal.duchy.ComputationsGrpcKt.ComputationsCoroutineStub
 import org.wfanet.measurement.internal.duchy.MetricValuesGrpcKt.MetricValuesCoroutineStub
@@ -86,6 +87,7 @@ abstract class LiquidLegionsV2MillDaemon : Runnable {
       computationStatsClient = computationStatsClient,
       workerStubs = computationControlClientMap,
       cryptoKeySet = newCryptoKeySet(),
+      duchyOrder = latestDuchyPublicKeys.toDuchyOrder(),
       cryptoWorker = JniLiquidLegionsV2Encryption(),
       throttler = MinimumIntervalThrottler(Clock.systemUTC(), flags.pollingInterval),
       requestChunkSizeBytes = flags.requestChunkSizeBytes,

--- a/cross-media-measurement/src/test/kotlin/org/wfanet/measurement/integration/common/InProcessDuchy.kt
+++ b/cross-media-measurement/src/test/kotlin/org/wfanet/measurement/integration/common/InProcessDuchy.kt
@@ -217,6 +217,7 @@ class InProcessDuchy(
         computationStatsClient = computationStatsStub,
         workerStubs = workerStubs,
         cryptoKeySet = duchyDependencies.cryptoKeySet,
+        duchyOrder = duchyDependencies.duchyPublicKeys.latest.toDuchyOrder(),
         cryptoWorker = JniLiquidLegionsV2Encryption(),
         throttler = MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
         requestChunkSizeBytes = 2_000_000


### PR DESCRIPTION
The partiallyCombinedPublicKey would be used to encrypt flags in the frequency noise tuples.

If the duchy ring is A->B->C->D, and A is the aggregator.
1. mill in B would get a key combined from publicKey_C, publicKey_D and publicKey_A.
2. mill in C would get a key combined from publicKey_D and publicKey_A.
3. mill in D would get a key equal to publicKey_A.
4. mill in A won't call this method, it would use the fulling combined key.