### PR TITLE
Set noise parameters in all requests in the mill if it is configured.

### DIFF
--- a/cross-media-measurement/src/main/kotlin/org/wfanet/measurement/duchy/daemon/mill/MillBase.kt
+++ b/cross-media-measurement/src/main/kotlin/org/wfanet/measurement/duchy/daemon/mill/MillBase.kt
@@ -463,7 +463,7 @@ const val CURRENT_RUNTIME_MEMORY_FREE = "current_runtime_memory_free"
 
 data class CachedResult(val bytes: Flow<ByteString>, val token: ComputationToken)
 
-data class LiquidLegionsConfig(val decayRate: Double, val size: Long, val maxFrequency: Int)
+data class LiquidLegionsConfig(val decayRate: Double, val size: Long)
 
 class PermanentComputationError(cause: Throwable) : Exception(cause)
 

--- a/cross-media-measurement/src/main/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv1/LiquidLegionsV1Mill.kt
+++ b/cross-media-measurement/src/main/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv1/LiquidLegionsV1Mill.kt
@@ -74,6 +74,7 @@ import org.wfanet.measurement.system.v1alpha.LiquidLegionsV1
  *    computationControlClients, used for passing computation to other duchies.
  * @param cryptoKeySet The set of crypto keys used in the computation.
  * @param cryptoWorker The cryptoWorker that performs the actual computation.
+ * @param maxFrequency The maximum frequency to reveal in the frequency histogram.
  * @param liquidLegionsConfig The configuration of the LiquidLegions sketch.
  */
 class LiquidLegionsV1Mill(
@@ -88,10 +89,10 @@ class LiquidLegionsV1Mill(
   private val workerStubs: Map<String, ComputationControlCoroutineStub>,
   private val cryptoKeySet: CryptoKeySet,
   private val cryptoWorker: LiquidLegionsV1Encryption,
+  private val maxFrequency: Int = 10,
   private val liquidLegionsConfig: LiquidLegionsConfig = LiquidLegionsConfig(
     12.0,
-    10_000_000L,
-    10
+    10_000_000L
   )
 ) : MillBase(
   millId,
@@ -333,7 +334,7 @@ class LiquidLegionsV1Mill(
             .setCurveId(cryptoKeySet.curveId.toLong())
             .setLocalElGamalKeyPair(cryptoKeySet.ownPublicAndPrivateKeys)
             .setFlagCounts(readAndCombineAllInputBlobs(token, 1))
-            .setMaximumFrequency(liquidLegionsConfig.maxFrequency)
+            .setMaximumFrequency(maxFrequency)
             .build()
         )
       logStageDurationMetric(token, CRYPTO_LIB_CPU_DURATION, cryptoResult.elapsedCpuTimeMillis)

--- a/cross-media-measurement/src/main/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv2/BUILD.bazel
+++ b/cross-media-measurement/src/main/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv2/BUILD.bazel
@@ -28,6 +28,7 @@ kt_jvm_library(
         "//src/main/kotlin/org/wfanet/measurement/duchy/db/computation",
         "//src/main/kotlin/org/wfanet/measurement/duchy/service/system/v1alpha:advance_computation_request_headers",
         "//src/main/proto/wfa/measurement/common/crypto:liquid_legions_v2_encryption_methods_java_proto",
+        "//src/main/proto/wfa/measurement/common/crypto:liquid_legions_v2_noise_config_java_proto",
         "//src/main/proto/wfa/measurement/internal/duchy:metric_values_service_kt_jvm_grpc",
         "//src/main/proto/wfa/measurement/protocol:liquid_legions_v2_java_proto",
         "//src/main/proto/wfa/measurement/system/v1alpha:computation_control_service_kt_jvm_grpc",

--- a/cross-media-measurement/src/main/kotlin/org/wfanet/measurement/duchy/deploy/common/daemon/mill/liquidlegionsv1/LiquidLegionsV1MillDaemon.kt
+++ b/cross-media-measurement/src/main/kotlin/org/wfanet/measurement/duchy/deploy/common/daemon/mill/liquidlegionsv1/LiquidLegionsV1MillDaemon.kt
@@ -89,10 +89,10 @@ abstract class LiquidLegionsV1MillDaemon : Runnable {
       cryptoWorker = JniLiquidLegionsV1Encryption(),
       throttler = MinimumIntervalThrottler(Clock.systemUTC(), flags.pollingInterval),
       requestChunkSizeBytes = flags.requestChunkSizeBytes,
+      maxFrequency = flags.sketchMaxFrequency,
       liquidLegionsConfig = LiquidLegionsConfig(
         flags.liquidLegionsDecayRate,
-        flags.liquidLegionsSize,
-        flags.sketchMaxFrequency
+        flags.liquidLegionsSize
       )
     )
 

--- a/cross-media-measurement/src/main/kotlin/org/wfanet/measurement/duchy/deploy/common/daemon/mill/liquidlegionsv2/LiquidLegionsV2MillDaemon.kt
+++ b/cross-media-measurement/src/main/kotlin/org/wfanet/measurement/duchy/deploy/common/daemon/mill/liquidlegionsv2/LiquidLegionsV2MillDaemon.kt
@@ -18,6 +18,7 @@ import io.grpc.ManagedChannel
 import java.time.Clock
 import kotlinx.coroutines.runBlocking
 import org.wfanet.measurement.common.crypto.ElGamalKeyPair
+import org.wfanet.measurement.common.crypto.LiquidLegionsV2NoiseConfig
 import org.wfanet.measurement.common.crypto.liquidlegionsv2.JniLiquidLegionsV2Encryption
 import org.wfanet.measurement.common.grpc.buildChannel
 import org.wfanet.measurement.common.hexAsByteString
@@ -91,11 +92,13 @@ abstract class LiquidLegionsV2MillDaemon : Runnable {
       cryptoWorker = JniLiquidLegionsV2Encryption(),
       throttler = MinimumIntervalThrottler(Clock.systemUTC(), flags.pollingInterval),
       requestChunkSizeBytes = flags.requestChunkSizeBytes,
+      maxFrequency = flags.sketchMaxFrequency,
       liquidLegionsConfig = LiquidLegionsConfig(
         flags.liquidLegionsDecayRate,
-        flags.liquidLegionsSize,
-        flags.sketchMaxFrequency
-      )
+        flags.liquidLegionsSize
+      ),
+      // TODO: read the noise config from config file.
+      noiseConfig = LiquidLegionsV2NoiseConfig.getDefaultInstance()
     )
 
     runBlocking { mill.continuallyProcessComputationQueue() }

--- a/cross-media-measurement/src/main/proto/wfa/measurement/common/crypto/BUILD.bazel
+++ b/cross-media-measurement/src/main/proto/wfa/measurement/common/crypto/BUILD.bazel
@@ -58,3 +58,16 @@ java_proto_library(
     name = "liquid_legions_v2_encryption_methods_java_proto",
     deps = [":liquid_legions_v2_encryption_methods_proto"],
 )
+
+proto_library(
+    name = "liquid_legions_v2_noise_config_proto",
+    srcs = ["liquid_legions_v2_noise_config.proto"],
+    strip_import_prefix = "/src/main/proto",
+    visibility = ["//visibility:private"],
+    deps = [":parameters_proto"],
+)
+
+java_proto_library(
+    name = "liquid_legions_v2_noise_config_java_proto",
+    deps = [":liquid_legions_v2_noise_config_proto"],
+)

--- a/cross-media-measurement/src/main/proto/wfa/measurement/common/crypto/liquid_legions_v2_noise_config.proto
+++ b/cross-media-measurement/src/main/proto/wfa/measurement/common/crypto/liquid_legions_v2_noise_config.proto
@@ -1,0 +1,48 @@
+// Copyright 2020 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.common.crypto;
+
+import "wfa/measurement/common/crypto/parameters.proto";
+
+option java_package = "org.wfanet.measurement.common.crypto";
+option java_multiple_files = true;
+
+// Noise parameters selected for the LiquidLegionV2 MPC protocol.
+// Only used as the configuration file consumed by the LiquidLegionV2Mill.
+message LiquidLegionsV2NoiseConfig {
+  message ReachNoiseConfig {
+    // DP params for the blind histogram noise register.
+    // Each of these registers contains a random register id, the same constant
+    // key indicating that the register is destroyed, and an arbitrary count
+    // value.
+    DifferentialPrivacyParams blind_histogram_noise = 1;
+    // DP params for the noise for the publisher noise registers.
+    // Each of these registers contains a well-known constant register id, and
+    // arbitrary key and count values.
+    DifferentialPrivacyParams noise_for_publisher_noise = 2;
+    // DP params for the global reach DP noise registers.
+    // Each of these registers contains a random register id which is out of
+    // bounds of the normal id space, the same constant key indicating that the
+    // register is destroyed, and an arbitrary count value.
+    DifferentialPrivacyParams global_reach_dp_noise = 3;
+  }
+  ReachNoiseConfig reach_noise_config = 1;
+
+  // Differential privacy parameters for noise tuples.
+  // Same value is used for both (0, R, R) and (R, R, R) tuples.
+  DifferentialPrivacyParams frequency_noise_config = 2;
+}

--- a/cross-media-measurement/src/test/kotlin/org/wfanet/measurement/integration/common/InProcessDuchy.kt
+++ b/cross-media-measurement/src/test/kotlin/org/wfanet/measurement/integration/common/InProcessDuchy.kt
@@ -26,6 +26,7 @@ import org.junit.runners.model.Statement
 import org.wfanet.measurement.api.v1alpha.DataProviderRegistrationGrpcKt.DataProviderRegistrationCoroutineStub
 import org.wfanet.measurement.api.v1alpha.PublisherDataGrpcKt.PublisherDataCoroutineStub
 import org.wfanet.measurement.api.v1alpha.RequisitionGrpcKt.RequisitionCoroutineStub
+import org.wfanet.measurement.common.crypto.LiquidLegionsV2NoiseConfig
 import org.wfanet.measurement.common.crypto.liquidlegionsv1.JniLiquidLegionsV1Encryption
 import org.wfanet.measurement.common.crypto.liquidlegionsv2.JniLiquidLegionsV2Encryption
 import org.wfanet.measurement.common.grpc.testing.GrpcTestServerRule
@@ -220,7 +221,8 @@ class InProcessDuchy(
         duchyOrder = duchyDependencies.duchyPublicKeys.latest.toDuchyOrder(),
         cryptoWorker = JniLiquidLegionsV2Encryption(),
         throttler = MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
-        requestChunkSizeBytes = 2_000_000
+        requestChunkSizeBytes = 2_000_000,
+        noiseConfig = LiquidLegionsV2NoiseConfig.getDefaultInstance()
       )
 
       liquidLegionsV2mill.continuallyProcessComputationQueue()


### PR DESCRIPTION
The mill would read the noise config from a textproto file instead of from flags for better readability.

The next step is to use a non-default noise config in the integrationTest.

Other minor changes:
The max_frequency is moved out of the LiquidLegionsConfig since it doesn't belong there anyway.