### PR TITLE
Remove references to "metric" from public API

### DIFF
--- a/cross-media-measurement-api/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
+++ b/cross-media-measurement-api/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
@@ -38,9 +38,7 @@ proto_library(
     srcs = ["requisition_spec.proto"],
     strip_import_prefix = IMPORT_PREFIX,
     deps = [
-        ":crypto_proto",
         ":data_provider_proto",
-        ":sketch_proto",
         "@com_google_protobuf//:timestamp_proto",
     ],
 )
@@ -153,5 +151,6 @@ proto_library(
         ":crypto_proto",
         ":data_provider_proto",
         ":measurement_consumer_proto",
+        ":sketch_proto",
     ],
 )

--- a/cross-media-measurement-api/src/main/proto/wfa/measurement/api/v2alpha/measurement.proto
+++ b/cross-media-measurement-api/src/main/proto/wfa/measurement/api/v2alpha/measurement.proto
@@ -101,7 +101,7 @@ message Measurement {
 
   enum State {
     STATE_UNSPECIFIED = 0;
-    // Waiting for all linked metric requisitions to be fulfilled.
+    // Waiting for all linked `Requisition`s to be fulfilled.
     AWAITING_REQUISITION_FULFILLMENT = 1;
     // Computation is running.
     COMPUTING = 2;
@@ -159,8 +159,8 @@ message MeasurementSpec {
     // Resource key of the sketch configuration. Required.
     SketchConfig.Key sketch_config = 1;
 
-    // The resource key of the CombinedPublicKey that is used to encrypt the
-    // metric value. Required.
+    // The resource key of the `CombinedPublicKey` that is used to encrypt the
+    // sketch. Required.
     CombinedPublicKey.Key combined_public_key = 2;
   }
 

--- a/cross-media-measurement-api/src/main/proto/wfa/measurement/api/v2alpha/measurement.proto
+++ b/cross-media-measurement-api/src/main/proto/wfa/measurement/api/v2alpha/measurement.proto
@@ -19,6 +19,7 @@ package wfa.measurement.api.v2alpha;
 import "wfa/measurement/api/v2alpha/crypto.proto";
 import "wfa/measurement/api/v2alpha/data_provider.proto";
 import "wfa/measurement/api/v2alpha/measurement_consumer.proto";
+import "wfa/measurement/api/v2alpha/sketch.proto";
 
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
@@ -37,9 +38,9 @@ message Measurement {
   // Resource key of the `MeasurementConsumerCertificate`. Required. Immutable.
   MeasurementConsumerCertificate.Key measurement_consumer_certificate = 2;
 
-  // Serialized `MetricDefinition` for requisitions, which can be verified using
+  // Serialized `MeasurementSpec` for requisitions, which can be verified using
   // `measurement_consumer_certificate`. Required. Immutable.
-  SignedData metric_definition = 3;
+  SignedData measurement_spec = 3;
 
   // Concatenation of the serialized `DataProvider` resource keys in
   // `data_provider_entries`. Required. Immutable.
@@ -78,7 +79,7 @@ message Measurement {
     // `measurement_consumer_certificate`. Required. Immutable.
     //
     // The symmetric encryption key is derived using a key-agreement protocol
-    // between `measurement_public_key` in `metric_definition` and
+    // between `measurement_public_key` in `measurement_spec` and
     // `data_provider_public_key`.
     bytes encrypted_requisition_spec = 4;
 
@@ -90,7 +91,7 @@ message Measurement {
     // 1. The SHA256 hash of `encrypted_requisition_spec`.
     // 2. The SHA256 hash of the concatenation of
     //    `serialized_data_provider_list` and `data_provider_list_salt`.
-    // 3. The `data` in `metric_definition`.
+    // 3. The `data` in `measurement_spec`.
     bytes data_provider_participation_signature = 5;
   }
   // The measurement entry for each `DataProvider`. This can be logically
@@ -143,7 +144,30 @@ message Measurement {
   // is `SUCCEEDED`.
   //
   // The symmetric encryption key is derived using a key-agreement protocol
-  // between `measurement_public_key` in `metric_definition` and
+  // between `measurement_public_key` in `measurement_spec` and
   // `result_public_key`.
   bytes encrypted_result = 11;
+}
+
+// Specification for a `Measurement`. Immutable.
+message MeasurementSpec {
+  // Encryption public key for the `Measurement` that this `MeasurementSpec` is
+  // associated with. Required.
+  bytes measurement_public_key = 1;
+
+  message EncryptedSketch {
+    // Resource key of the sketch configuration. Required.
+    SketchConfig.Key sketch_config = 1;
+
+    // The resource key of the CombinedPublicKey that is used to encrypt the
+    // metric value. Required.
+    CombinedPublicKey.Key combined_public_key = 2;
+  }
+
+  // What data the requisition is for, i.e. what data is being requisitioned.
+  // Required.
+  oneof for {
+    // The data being requisitioned is an encrypted sketch.
+    EncryptedSketch encrypted_sketch = 2;
+  }
 }

--- a/cross-media-measurement-api/src/main/proto/wfa/measurement/api/v2alpha/measurement.proto
+++ b/cross-media-measurement-api/src/main/proto/wfa/measurement/api/v2alpha/measurement.proto
@@ -85,7 +85,7 @@ message Measurement {
 
     // Cryptographic digital signature of the "requisition fingerprint" which
     // can be verified using the `DataProvider`'s certificate. Output-only. Only
-    // set if the corresponding `MetricRequisition` has been fulfilled.
+    // set if the corresponding `Requisition` has been fulfilled.
     //
     // The requisition fingerprint is defined as the concatenation of:
     // 1. The SHA256 hash of `encrypted_requisition_spec`.

--- a/cross-media-measurement-api/src/main/proto/wfa/measurement/api/v2alpha/requisition.proto
+++ b/cross-media-measurement-api/src/main/proto/wfa/measurement/api/v2alpha/requisition.proto
@@ -42,9 +42,9 @@ message MetricRequisition {
   // `measurement`. Required. Immutable.
   MeasurementConsumerCertificate measurement_consumer_certificate = 3;
 
-  // Denormalized `metric_definition` field from `measurement`. Required.
+  // Denormalized `measurement_spec` field from `measurement`. Required.
   // Immutable.
-  SignedData metric_definition = 4;
+  SignedData measurement_spec = 4;
 
   // Denormalized `data_provider_public_key` field from the corresponding
   // `DataProviderEntry` in `measurement`.  Required. Immutable.
@@ -78,15 +78,16 @@ message MetricRequisition {
       // previously existed but has been deleted.
       UNKNOWN_EVENT_GROUP = 1;
 
-      // The `MetricDefinition` specifies a configuration that the
+      // The `MeasurementSpec` specifies a configuration that the
       // `DataProvider` does not and will never support for this `EventGroup`.
-      METRIC_DEFINITION_UNSUPPORTED = 2;
+      MEASUREMENT_SPEC_UNSUPPORTED = 2;
 
       // The collection interval covers a range that is sufficiently long ago
       // that the DataProvider no longer retains the underlying data.
       COLLECTION_INTERVAL_TOO_DISTANT = 3;
 
-      // Validation of the `MetricRequisition.Spec` signature failed.
+      // Validation of the `measurement_spec` or `encrypted_requisition_spec`
+      // signature failed.
       SIGNATURE_INVALID = 4;
 
       // There is insufficient remaining privacy budget to fulfill this
@@ -97,9 +98,9 @@ message MetricRequisition {
       // The data required to fulfill this request may or may not be available.
       DECLINED = 6;
 
-      // The data required to fulfill this MetricRequisition is inaccessible or
-      // lost. This should only be used when there is no other Justification
-      // that is more specific.
+      // The data required to fulfill this `MetricRequisition` is inaccessible
+      // or lost. This should only be used when there is no other
+      // `Justification` that is more specific.
       DATA_UNAVAILABLE = 7;
     }
     Justification justification = 1;

--- a/cross-media-measurement-api/src/main/proto/wfa/measurement/api/v2alpha/requisition.proto
+++ b/cross-media-measurement-api/src/main/proto/wfa/measurement/api/v2alpha/requisition.proto
@@ -24,18 +24,22 @@ option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "RequisitionProto";
 
-// A requisition for a single metric across a set of `EventGroup`s from a single
-// `DataProvider`. Output-only.
-message MetricRequisition {
+// A requisition for data across `EventGroup`s from a single `DataProvider`.
+// Output-only.
+//
+// A `Requisition` is created on behalf of a `MeasurementConsumer` to instruct a
+// `DataProvider` to collect and upload data necessary to compute a
+// `Measurement` result.
+message Requisition {
   message Key {
     string data_provider_id = 1;
-    string metric_requisition_id = 2;
+    string requisition_id = 2;
   }
   // Resource key.
   Key key = 1;
 
-  // Resource key of `Measurement` that this `MetricRequisition` is associated
-  // with. Required. Immutable.
+  // Resource key of `Measurement` that this `Requisition` is associated with.
+  // Required. Immutable.
   Measurement.Key measurement = 2;
 
   // Denormalized dereferenced `measurement_consumer_certificate` field from
@@ -54,19 +58,19 @@ message MetricRequisition {
   // `DataProviderEntry` in `measurement`.  Required. Immutable.
   bytes encrypted_requisition_spec = 6;
 
-  // State of a metrics requisition.
+  // State of a `Requisition`.
   enum State {
     // Default value if state is omitted. Should never be used.
     STATE_UNSPECIFIED = 0;
-    // No metric value has been sent to fulfill this requisition.
+    // The `Requisition` has not yet been fulfilled.
     UNFULFILLED = 1;
-    // A metric value has been sent to fulfill this requisition. Terminal state.
+    // The `Requisition` has been fulfilled. Terminal state.
     FULFILLED = 2;
-    // The requisition cannot be fulfilled. Terminal state. Any Measurements
-    // using this requisition will be put into the FAILED state.
+    // The `Requisition` cannot be fulfilled. Terminal state. Any `Measurement`s
+    // using this `Requisition` will be put into the `FAILED` state.
     UNFULFILLABLE = 3;
   }
-  // The state of this requisition.
+  // The state of this `Requisition`.
   State state = 7;
 
   message Refusal {
@@ -91,22 +95,22 @@ message MetricRequisition {
       SIGNATURE_INVALID = 4;
 
       // There is insufficient remaining privacy budget to fulfill this
-      // `MetricRequisition`.
+      // `Requisition`.
       INSUFFICIENT_PRIVACY_BUDGET = 5;
 
-      // The `DataProvider` has declined to fulfill this `MetricRequisition`.
-      // The data required to fulfill this request may or may not be available.
+      // The `DataProvider` has declined to fulfill this `Requisition`. The data
+      // required to fulfill this request may or may not be available.
       DECLINED = 6;
 
-      // The data required to fulfill this `MetricRequisition` is inaccessible
-      // or lost. This should only be used when there is no other
-      // `Justification` that is more specific.
+      // The data required to fulfill this `Requisition` is inaccessible or
+      // lost. This should only be used when there is no other `Justification`
+      // that is more specific.
       DATA_UNAVAILABLE = 7;
     }
     Justification justification = 1;
 
-    // Human-readable string adding more context to the provided Justification.
-    // This should NOT include sensitive information.
+    // Human-readable string adding more context to the provided
+    // `Justification`. This should NOT include sensitive information.
     //
     // Example: "Data Provider X does not support Virtual ID model line Y".
     string message = 2;

--- a/cross-media-measurement-api/src/main/proto/wfa/measurement/api/v2alpha/requisition_fulfillment_service.proto
+++ b/cross-media-measurement-api/src/main/proto/wfa/measurement/api/v2alpha/requisition_fulfillment_service.proto
@@ -43,7 +43,7 @@ message FulfillMetricRequisitionRequest {
     // 1. The SHA256 hash of `encrypted_requisition_spec` from the
     //    `MetricRequisition`.
     // 2. `data_provider_list_hash` from the `MetricRequisition`.
-    // 3. The `data` in `metric_definition` from the `MetricRequisition`.
+    // 3. The `data` in `measurement_spec` from the `MetricRequisition`.
     bytes data_provider_participation_signature = 2;
   }
 
@@ -52,7 +52,7 @@ message FulfillMetricRequisitionRequest {
     // The portion of the data for this `BodyChunk`, encrypted using the
     // `CombinedPublicKey` specified in the `MetricRequisition`. Required.
     //
-    // If the corresponding `MetricDefinition` is a sketch, this is the register
+    // If the corresponding `MeasurementSpec` is a sketch, this is the register
     // data as documented in the `Sketch` message (sketch.proto). The only
     // alignment requirement is by bytes: a chunk might begin or end in the
     // middle of a single register.

--- a/cross-media-measurement-api/src/main/proto/wfa/measurement/api/v2alpha/requisition_fulfillment_service.proto
+++ b/cross-media-measurement-api/src/main/proto/wfa/measurement/api/v2alpha/requisition_fulfillment_service.proto
@@ -22,43 +22,43 @@ option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "RequisitionFulfillmentServiceProto";
 
-// Duchy service for fulfilling `MetricRequisition`s.
+// Duchy service for fulfilling `Requisition`s.
 service RequisitionFulfillment {
-  // Fulfills a `MetricRequisition`.
-  rpc FulfillMetricRequisition(stream FulfillMetricRequisitionRequest)
-      returns (FulfillMetricRequisitionResponse) {}
+  // Fulfills a `Requisition`.
+  rpc FulfillRequisition(stream FulfillRequisitionRequest)
+      returns (FulfillRequisitionResponse) {}
 }
 
-// Request message for `FulfillMetricRequisition` method.
-message FulfillMetricRequisitionRequest {
+// Request message for `FulfillRequisition` method.
+message FulfillRequisitionRequest {
   // The header message for this streaming request.
   message Header {
-    // Resource key of the `MetricRequisition`. Required.
-    MetricRequisition.Key key = 1;
+    // Resource key of the `Requisition`. Required.
+    Requisition.Key key = 1;
 
     // Cryptographic digital signature of the "requisition fingerprint" which
     // can be verified using the `DataProvider`'s certificate. Required.
     //
     // The requisition fingerprint is defined as the concatenation of:
     // 1. The SHA256 hash of `encrypted_requisition_spec` from the
-    //    `MetricRequisition`.
-    // 2. `data_provider_list_hash` from the `MetricRequisition`.
-    // 3. The `data` in `measurement_spec` from the `MetricRequisition`.
+    //    `Requisition`.
+    // 2. `data_provider_list_hash` from the `Requisition`.
+    // 3. The `data` in `measurement_spec` from the `Requisition`.
     bytes data_provider_participation_signature = 2;
   }
 
   // The chunk message for this streaming request.
   message BodyChunk {
-    // The portion of the data for this `BodyChunk`, encrypted using the
-    // `CombinedPublicKey` specified in the `MetricRequisition`. Required.
+    // The portion of the data for this `BodyChunk`. Required.
     //
-    // If the corresponding `MeasurementSpec` is a sketch, this is the register
-    // data as documented in the `Sketch` message (sketch.proto). The only
-    // alignment requirement is by bytes: a chunk might begin or end in the
-    // middle of a single register.
+    // The format of the data depends on the corresponding `MeasurementSpec`. If
+    // the `Requisition` is for an encrypted sketch, this is the register
+    // data as documented in the `Sketch` message (sketch.proto) encrypted using
+    // the specified `CombinedPublicKey`. The only alignment requirement is by
+    // bytes: a chunk might begin or end in the middle of a single register.
     //
     // The optimal size of this field is one that would result in the
-    // `FulfillMetricRequisitionRequest` message being between 16KiB and 64KiB.
+    // `FulfillRequisitionRequest` message being between 16KiB and 64KiB.
     // See https://github.com/grpc/grpc.github.io/issues/371
     bytes data = 1;
   }
@@ -75,8 +75,8 @@ message FulfillMetricRequisitionRequest {
   }
 }
 
-// Response message for `FulfillMetricRequisition` method.
-message FulfillMetricRequisitionResponse {
-  // Resulting state of the `MetricRequisition`.
-  MetricRequisition.State state = 1;
+// Response message for `FulfillRequisition` method.
+message FulfillRequisitionResponse {
+  // Resulting state of the `Requisition`.
+  Requisition.State state = 1;
 }

--- a/cross-media-measurement-api/src/main/proto/wfa/measurement/api/v2alpha/requisition_spec.proto
+++ b/cross-media-measurement-api/src/main/proto/wfa/measurement/api/v2alpha/requisition_spec.proto
@@ -25,7 +25,7 @@ option java_outer_classname = "RequisitionSpecProto";
 
 // Specification for a `Requisition` which can be cryptographically signed.
 message RequisitionSpec {
-  // Filter to apply to metric events.
+  // Filter to apply to events.
   message EventFilter {
     // Age, gender identity, viewable duration, etc.
     // TODO: Design and add filter predicates.
@@ -60,10 +60,10 @@ message RequisitionSpec {
     // Resource key of the `EventGroup` that this entry is for. Required.
     EventGroup.Key event_group = 1;
 
-    // Time interval over which the metric should be collected. Required.
+    // Time interval over which the event data should be collected. Required.
     TimeInterval collection_interval = 2;
 
-    // Optional filter to apply to metric events.
+    // Optional filter to apply to events.
     EventFilter filter = 3;
   }
   // The requisition entry for each `EventGroup`. This can be logically

--- a/cross-media-measurement-api/src/main/proto/wfa/measurement/api/v2alpha/requisition_spec.proto
+++ b/cross-media-measurement-api/src/main/proto/wfa/measurement/api/v2alpha/requisition_spec.proto
@@ -17,9 +17,7 @@ syntax = "proto3";
 package wfa.measurement.api.v2alpha;
 
 import "google/protobuf/timestamp.proto";
-import "wfa/measurement/api/v2alpha/crypto.proto";
 import "wfa/measurement/api/v2alpha/data_provider.proto";
-import "wfa/measurement/api/v2alpha/sketch.proto";
 
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
@@ -85,29 +83,6 @@ message RequisitionSpec {
   // `data_provider_list_salt` from the `Measurement` that this
   // `RequistionSpec` is associated with. Required. Immutable.
   bytes data_provider_list_hash = 3;
-}
-
-// Representation of a metric to be collected.
-message MetricDefinition {
-  // Representation of a metric to be collected as a sketch.
-  message Sketch {
-    // Resource key of the sketch configuration. Required.
-    SketchConfig.Key sketch_config = 1;
-  }
-
-  // Exactly one of these must be specified.
-  oneof definition {
-    // A metric to be collected as a sketch.
-    Sketch sketch = 1;
-  }
-
-  // The resource key of the CombinedPublicKey that is used to encrypt the
-  // metric value. Required. Immutable.
-  CombinedPublicKey.Key combined_public_key = 2;
-
-  // Encryption public key for the `Measurement` that this `MetricDefinition` is
-  // associated with. Required. Immutable.
-  bytes measurement_public_key = 3;
 }
 
 // A time interval.

--- a/cross-media-measurement-api/src/main/proto/wfa/measurement/api/v2alpha/requisition_spec.proto
+++ b/cross-media-measurement-api/src/main/proto/wfa/measurement/api/v2alpha/requisition_spec.proto
@@ -23,8 +23,7 @@ option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "RequisitionSpecProto";
 
-// Specification for a `MetricRequisition` which can be cryptographically
-// signed.
+// Specification for a `Requisition` which can be cryptographically signed.
 message RequisitionSpec {
   // Filter to apply to metric events.
   message EventFilter {
@@ -72,7 +71,7 @@ message RequisitionSpec {
   // Immutable.
   //
   // All of the `EventGroup`s must belong to the same parent `DataProvider`
-  // as this `MetricRequisition`.
+  // as this `Requisition`.
   repeated EventGroupEntry event_group_entries = 1;
 
   // Encryption public key for the `Measurement` that this `RequisitionSpec` is

--- a/cross-media-measurement-api/src/main/proto/wfa/measurement/api/v2alpha/requisitions_service.proto
+++ b/cross-media-measurement-api/src/main/proto/wfa/measurement/api/v2alpha/requisitions_service.proto
@@ -23,35 +23,29 @@ option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
 option java_outer_classname = "RequisitionsServiceProto";
 
-// Service for interacting with `MetricRequisition`s.
-//
-// `MetricRequisition`s are created on behalf of `MeasurementConsumer`s to
-// instruct `DataProvider`s to collect and upload the metric value necessary
-// to compute a `Measurement` result.
+// Service for interacting with `Requisition` resources.
 service Requisitions {
-  // Returns the metric requisitions for the specified `EventGroup`.
-  rpc ListMetricRequisitions(ListMetricRequisitionsRequest)
-      returns (ListMetricRequisitionsResponse);
+  // Returns the `Requisition`s for the specified `EventGroup`.
+  rpc ListRequisitions(ListRequisitionsRequest)
+      returns (ListRequisitionsResponse);
 
-  // Marks a `MetricRequisition` as unfulfillable, transitioning it to the
-  // `UNFULFILLABLE` state. This is a terminal state for the `MetricRequisition`
-  // and all computations that rely on the `MetricRequisition` will fail.
-  // Consequently, this should only be used for permanent failures and not
-  // transient errors.
+  // Marks a `Requisition` as unfulfillable, transitioning it to the
+  // `UNFULFILLABLE` state. This is a terminal state for the `Requisition` and
+  // all computations that rely on the `Requisition` will fail. Consequently,
+  // this should only be used for permanent failures and not transient errors.
   //
   // This is a state transition method (see https://aip.dev/216).
-  rpc RefuseMetricRequisition(RefuseMetricRequisitionRequest)
-      returns (MetricRequisition);
+  rpc RefuseRequisition(RefuseRequisitionRequest) returns (Requisition);
 }
 
-// Request message for `ListMetricRequisitions` method.
-message ListMetricRequisitionsRequest {
+// Request message for `ListRequisitions` method.
+message ListRequisitionsRequest {
   // Resource key of the parent `EventGroup`. Required. `event_group_id` may be
   // omitted to list across all `EventGroup`s for the specified `DataProvider`.
   //
   // Results in a `PERMISSION_DENIED` error if any key segment does not match
   // for the authenticated user. For example, attempting to list
-  // `MetricRequisition`s for other `DataProvider`s or for `EventGroup`s
+  // `Requisition`s for other `DataProvider`s or for `EventGroup`s
   // belonging to other `MeasurementConsumer`s.
   EventGroup.Key parent = 1;
 
@@ -64,28 +58,28 @@ message ListMetricRequisitionsRequest {
   // Filter criteria. Repeated fields are treated as logical ORs, and multiple
   // fields specified as logical ANDs.
   message Filter {
-    repeated MetricRequisition.State states = 1;
+    repeated Requisition.State states = 1;
   }
   // Result filter. If a page token is specified, then this will be ignored and
   // the filter for the first page will be applied.
   Filter filter = 4;
 }
 
-// Response message for `ListMetricRequisitions` method.
-message ListMetricRequisitionsResponse {
-  // The `MetricRequisition` resources.
-  repeated MetricRequisition metric_requisitions = 1;
+// Response message for `ListRequisitions` method.
+message ListRequisitionsResponse {
+  // The `Requisition` resources.
+  repeated Requisition requisitions = 1;
 
   // A token that can be specified in a subsequent call to retrieve the next
   // page. See https://aip.dev/158.
   string next_page_token = 2;
 }
 
-// Request message for `RefuseMetricRequisition` method.
-message RefuseMetricRequisitionRequest {
-  // Resource key of the `MetricRequisition` to mark as `UNFILLABLE`. Required.
-  MetricRequisition.Key key = 1;
+// Request message for `RefuseRequisition` method.
+message RefuseRequisitionRequest {
+  // Resource key of the `Requisition` to mark as `UNFILLABLE`. Required.
+  Requisition.Key key = 1;
 
   // Details about the refusal.
-  MetricRequisition.Refusal refusal = 2;
+  Requisition.Refusal refusal = 2;
 }


### PR DESCRIPTION
The use of the term "metric" was inaccurate. This renames `MetricDefinition` to `MeasurementSpec` and `MetricRequisition` to `Requisition`.