### PR TITLE
Fix a bug in the reach estimating phase in the LLV2 protocol.

### DIFF
--- a/cross-media-measurement/src/main/cc/wfa/measurement/common/crypto/liquid_legions_v2_encryption_utility.cc
+++ b/cross-media-measurement/src/main/cc/wfa/measurement/common/crypto/liquid_legions_v2_encryption_utility.cc
@@ -480,7 +480,7 @@ absl::Status AddAllFrequencyNoise(
   auto options = GetFrequencyNoiseOptions(
       noise_parameters.dp_params(), noise_parameters.maximum_frequency(),
       noise_parameters.contributors_count());
-  int total_noise_tuples_count =
+  int64_t total_noise_tuples_count =
       options.shift_offset * 2 * (noise_parameters.maximum_frequency() + 1);
   ASSIGN_OR_RETURN(
       int frequency_dp_noise_tuples_count,
@@ -491,9 +491,9 @@ absl::Status AddAllFrequencyNoise(
       int destroyed_noise_tuples_count,
       AddDestroyedFrequencyNoise(full_protocol_cryptor,
                                  partial_protocol_cryptor, options, data));
-  int padding_noise_tuples_count = total_noise_tuples_count -
-                                   frequency_dp_noise_tuples_count -
-                                   destroyed_noise_tuples_count;
+  int64_t padding_noise_tuples_count = total_noise_tuples_count -
+                                       frequency_dp_noise_tuples_count -
+                                       destroyed_noise_tuples_count;
   RETURN_IF_ERROR(AddPaddingFrequencyNoise(full_protocol_cryptor,
                                            partial_protocol_cryptor,
                                            padding_noise_tuples_count, data));
@@ -511,7 +511,7 @@ absl::StatusOr<CompleteSetupPhaseResponse> CompleteSetupPhase(
   *response_crv = request.combined_register_vector();
 
   if (request.has_noise_parameters()) {
-    RegisterNoiseGenerationParameters noise_parameters =
+    const RegisterNoiseGenerationParameters& noise_parameters =
         request.noise_parameters();
     auto blind_histogram_noise_options = GetBlindHistogramNoiseOptions(
         noise_parameters.dp_params().blind_histogram(),
@@ -524,7 +524,7 @@ absl::StatusOr<CompleteSetupPhaseResponse> CompleteSetupPhase(
     auto global_reach_dp_noise_options = GetGlobalReachDpNoiseOptions(
         noise_parameters.dp_params().global_reach_dp_noise(),
         noise_parameters.contributors_count());
-    int total_noise_registers_count =
+    int64_t total_noise_registers_count =
         noise_for_publisher_noise_options.shift_offset * 2 +
         global_reach_dp_noise_options.shift_offset * 2 +
         blind_histogram_noise_options.shift_offset *
@@ -661,11 +661,9 @@ CompleteExecutionPhaseOneAtAggregator(
 
   // Add noise (flag_a, flag_b, flag_c, count) tuples if configured to.
   if (request.has_noise_parameters()) {
-    FlagCountTupleNoiseGenerationParameters noise_parameters =
-        request.noise_parameters();
-    RETURN_IF_ERROR(AddAllFrequencyNoise(*protocol_cryptor, *protocol_cryptor,
-                                         request.curve_id(), noise_parameters,
-                                         *response_data));
+    RETURN_IF_ERROR(AddAllFrequencyNoise(
+        *protocol_cryptor, *protocol_cryptor, request.curve_id(),
+        request.noise_parameters(), *response_data));
   }
 
   RETURN_IF_ERROR(SortStringByBlock<kBytesPerFlagsCountTuple>(*response_data));
@@ -712,8 +710,6 @@ absl::StatusOr<CompleteExecutionPhaseTwoResponse> CompleteExecutionPhaseTwo(
 
   // Add noise (flag_a, flag_b, flag_c, count) tuples if configured to.
   if (request.has_noise_parameters()) {
-    FlagCountTupleNoiseGenerationParameters noise_parameters =
-        request.noise_parameters();
     ASSIGN_OR_RETURN_ERROR(
         auto partial_protocol_cryptor,
         CreateProtocolCryptorWithKeys(
@@ -725,7 +721,7 @@ absl::StatusOr<CompleteExecutionPhaseTwoResponse> CompleteExecutionPhaseTwo(
         "Failed to create the protocol cipher, invalid curveId or keys.");
     RETURN_IF_ERROR(AddAllFrequencyNoise(
         *protocol_cryptor, *partial_protocol_cryptor, request.curve_id(),
-        noise_parameters, *response_data));
+        request.noise_parameters(), *response_data));
   }
 
   RETURN_IF_ERROR(SortStringByBlock<kBytesPerFlagsCountTuple>(*response_data));
@@ -770,7 +766,7 @@ CompleteExecutionPhaseTwoAtAggregator(
     absl::string_view current_block =
         absl::string_view(request.flag_count_tuples())
             .substr(index * kBytesPerFlagsCountTuple, kBytesPerFlagsCountTuple);
-    std::array<bool, 3> flags;
+    std::array<bool, 3> flags = {};
     for (int i = 0; i < 3; ++i) {
       ASSIGN_OR_RETURN(ElGamalCiphertext flag_ciphertext,
                        ExtractElGamalCiphertextFromString(current_block.substr(
@@ -806,7 +802,7 @@ CompleteExecutionPhaseTwoAtAggregator(
     auto options = GetGlobalReachDpNoiseOptions(
         request.reach_dp_noise_baseline().global_reach_dp_noise(),
         request.reach_dp_noise_baseline().contributors_count());
-    int global_reach_dp_noise_baseline = options.shift_offset * options.num;
+    int64_t global_reach_dp_noise_baseline = options.shift_offset * options.num;
     active_register_count -= global_reach_dp_noise_baseline;
     // Publisher noise and padding noise each contribute 1 additional destroyed
     // register, which shouldn't be included when estimating reach.
@@ -814,13 +810,14 @@ CompleteExecutionPhaseTwoAtAggregator(
     active_register_count -= 2;
   }
   if (request.has_frequency_noise_parameters()) {
-    FlagCountTupleNoiseGenerationParameters noise_parameters =
+    const FlagCountTupleNoiseGenerationParameters& noise_parameters =
         request.frequency_noise_parameters();
     auto options = GetFrequencyNoiseOptions(
         noise_parameters.dp_params(), noise_parameters.maximum_frequency(),
         noise_parameters.contributors_count());
-    int total_noise_tuples_count = options.num * options.shift_offset * 2 *
-                                   (noise_parameters.maximum_frequency() + 1);
+    int64_t total_noise_tuples_count =
+        options.num * options.shift_offset * 2 *
+        (noise_parameters.maximum_frequency() + 1);
     // Subtract all frequency noises before estimating reach.
     active_register_count -= total_noise_tuples_count;
   }
@@ -890,13 +887,13 @@ CompleteExecutionPhaseThreeAtAggregator(
         "maximum_frequency should be at least 2.");
   }
 
-  int row_size = maximum_frequency - 1;
+  int64_t row_size = maximum_frequency - 1;
   if (ciphertext_counts % row_size != 0) {
     return absl::InvalidArgumentError(
         "The size of the SameKeyAggregator matrix is not divisible by "
         "maximum_frequency-1.");
   }
-  int column_size = ciphertext_counts / row_size;
+  int64_t column_size = ciphertext_counts / row_size;
 
   ASSIGN_OR_RETURN_ERROR(
       auto protocol_cryptor,
@@ -915,7 +912,7 @@ CompleteExecutionPhaseThreeAtAggregator(
   std::vector<int> histogram(maximum_frequency);
   histogram[maximum_frequency - 1] = column_size;
 
-  absl::string_view same_key_aggregator_matrix =
+  auto same_key_aggregator_matrix =
       absl::string_view(request.same_key_aggregator_matrix());
   for (int column = 0; column < column_size; ++column) {
     for (int row = 0; row < row_size; ++row) {
@@ -944,10 +941,10 @@ CompleteExecutionPhaseThreeAtAggregator(
         request.global_frequency_dp_noise_per_bucket().dp_params(),
         request.maximum_frequency(),
         request.global_frequency_dp_noise_per_bucket().contributors_count());
-    int noise_baseline_per_bucket = options.shift_offset * options.num;
+    int64_t noise_baseline_per_bucket = options.shift_offset * options.num;
     actual_total = 0;
     for (int i = 0; i < maximum_frequency; ++i) {
-      histogram[i] = std::max(0, histogram[i] - noise_baseline_per_bucket);
+      histogram[i] = std::max(0L, histogram[i] - noise_baseline_per_bucket);
       actual_total += histogram[i];
     }
   }

--- a/cross-media-measurement/src/main/cc/wfa/measurement/common/crypto/noise_parameters_computation.cc
+++ b/cross-media-measurement/src/main/cc/wfa/measurement/common/crypto/noise_parameters_computation.cc
@@ -18,7 +18,7 @@ namespace wfa::measurement::common::crypto {
 
 namespace {
 
-int computate_mu_polya(double epsilon, double delta, int n) {
+int ComputateMuPolya(double epsilon, double delta, int n) {
   ABSL_ASSERT(epsilon > 0);
   ABSL_ASSERT(delta > 0);
   ABSL_ASSERT(n > 0);
@@ -34,9 +34,8 @@ math::DistributedGeometricRandomComponentOptions GetBlindHistogramNoiseOptions(
   ABSL_ASSERT(publisher_count > 0);
   ABSL_ASSERT(uncorrupted_party_count > 0);
   double success_ratio = std::exp(-params.epsilon() / 3);
-  int offset =
-      computate_mu_polya(params.epsilon() / 3, params.delta(),
-                         2 * uncorrupted_party_count * publisher_count);
+  int offset = ComputateMuPolya(params.epsilon() / 3, params.delta(),
+                                2 * uncorrupted_party_count * publisher_count);
   return {
       .num = uncorrupted_party_count,
       .p = success_ratio,
@@ -52,8 +51,8 @@ GetNoiseForPublisherNoiseOptions(const DifferentialPrivacyParams& params,
   ABSL_ASSERT(publisher_count > 0);
   ABSL_ASSERT(uncorrupted_party_count > 0);
   double success_ratio = std::exp(-params.epsilon() / publisher_count);
-  int offset = computate_mu_polya(params.epsilon() / publisher_count,
-                                  params.delta(), uncorrupted_party_count);
+  int offset = ComputateMuPolya(params.epsilon() / publisher_count,
+                                params.delta(), uncorrupted_party_count);
   return {
       .num = uncorrupted_party_count,
       .p = success_ratio,
@@ -66,8 +65,8 @@ math::DistributedGeometricRandomComponentOptions GetGlobalReachDpNoiseOptions(
     const DifferentialPrivacyParams& params, int uncorrupted_party_count) {
   ABSL_ASSERT(uncorrupted_party_count > 0);
   double success_ratio = std::exp(-params.epsilon());
-  int offset = computate_mu_polya(params.epsilon(), params.delta(),
-                                  uncorrupted_party_count);
+  int offset = ComputateMuPolya(params.epsilon(), params.delta(),
+                                uncorrupted_party_count);
   return {
       .num = uncorrupted_party_count,
       .p = success_ratio,
@@ -82,8 +81,8 @@ math::DistributedGeometricRandomComponentOptions GetFrequencyNoiseOptions(
   ABSL_ASSERT(max_frequency > 0);
   ABSL_ASSERT(uncorrupted_party_count > 0);
   double success_ratio = std::exp(-params.epsilon() / 2);
-  int offset = computate_mu_polya(params.epsilon() / 2, params.delta(),
-                                  2 * uncorrupted_party_count * max_frequency);
+  int offset = ComputateMuPolya(params.epsilon() / 2, params.delta(),
+                                2 * uncorrupted_party_count * max_frequency);
   return {
       .num = uncorrupted_party_count,
       .p = success_ratio,

--- a/cross-media-measurement/src/main/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv2/LiquidLegionsV2Mill.kt
+++ b/cross-media-measurement/src/main/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv2/LiquidLegionsV2Mill.kt
@@ -359,9 +359,16 @@ class LiquidLegionsV2Mill(
         }
       }
       if (noiseConfig.hasReachNoiseConfig()) {
-        requestBuilder.noiseBaselineBuilder.apply {
+        requestBuilder.reachDpNoiseBaselineBuilder.apply {
           contributorsCount = workerStubs.size + 1
           globalReachDpNoise = noiseConfig.reachNoiseConfig.globalReachDpNoise
+        }
+      }
+      if (noiseConfig.hasFrequencyNoiseConfig()) {
+        requestBuilder.frequencyNoiseParametersBuilder.apply {
+          contributorsCount = workerStubs.size + 1
+          maximumFrequency = maxFrequency
+          dpParams = noiseConfig.frequencyNoiseConfig
         }
       }
 

--- a/cross-media-measurement/src/main/proto/wfa/measurement/common/crypto/liquid_legions_v2_encryption_methods.proto
+++ b/cross-media-measurement/src/main/proto/wfa/measurement/common/crypto/liquid_legions_v2_encryption_methods.proto
@@ -212,14 +212,18 @@ message CompleteExecutionPhaseTwoAtAggregatorRequest {
   // The elliptical curve to work on for SKA generation.
   int64 curve_id = 4;
   // Maximum frequency to measure. At least 2.
-  // (maximum_frequency-1) will is the row dimension of the 2-D SKA matrix.
+  // (maximum_frequency-1) will be the row dimension of the 2-D SKA matrix.
   int32 maximum_frequency = 5;
   // LiquidLegions parameters used for reach estimation.
   LiquidLegionsParameters liquid_legions_parameters = 6;
   // Parameters for computing the noise baseline of the global reach DP noise
   // registers added in the setup phase.
   // The baseline is subtracted before reach is estimated.
-  GlobalReachDpNoiseBaseline noise_baseline = 7;
+  GlobalReachDpNoiseBaseline reach_dp_noise_baseline = 7;
+  // Parameters used to generate frequency noise tuples.
+  // The total number of frequency noise tuples should be subtracted from the
+  // number of active registers before estimating reach.
+  FlagCountTupleNoiseGenerationParameters frequency_noise_parameters = 8;
 }
 
 // The response of the CompleteExecutionPhaseTwoAtAggregator method.

--- a/cross-media-measurement/src/test/cc/wfa/measurement/common/crypto/liquid_legions_v2_encryption_utility_test.cc
+++ b/cross-media-measurement/src/test/cc/wfa/measurement/common/crypto/liquid_legions_v2_encryption_utility_test.cc
@@ -300,7 +300,7 @@ class TestData {
   absl::StatusOr<MpcResult> GoThroughEntireMpcProtocol(
       const std::string& encrypted_sketch,
       RegisterNoiseGenerationParameters* reach_noise_parameters,
-      FlagCountTupleNoiseGenerationParameters* frequency_noise_paraters) {
+      FlagCountTupleNoiseGenerationParameters* frequency_noise_parameters) {
     // Setup phase at Duchy 1.
     // We assume all test data comes from duchy 1 in the test.
     CompleteSetupPhaseRequest complete_setup_phase_request_1;
@@ -397,9 +397,9 @@ class TestData {
     complete_execution_phase_one_at_aggregator_request
         .set_combined_register_vector(
             complete_execution_phase_one_response_2.combined_register_vector());
-    if (frequency_noise_paraters != nullptr) {
+    if (frequency_noise_parameters != nullptr) {
       *complete_execution_phase_one_at_aggregator_request
-           .mutable_noise_parameters() = *frequency_noise_paraters;
+           .mutable_noise_parameters() = *frequency_noise_parameters;
     }
 
     ASSIGN_OR_RETURN(CompleteExecutionPhaseOneAtAggregatorResponse
@@ -420,9 +420,9 @@ class TestData {
     complete_execution_phase_two_request_1.set_flag_count_tuples(
         complete_execution_phase_one_at_aggregator_response
             .flag_count_tuples());
-    if (frequency_noise_paraters != nullptr) {
+    if (frequency_noise_parameters != nullptr) {
       *complete_execution_phase_two_request_1.mutable_noise_parameters() =
-          *frequency_noise_paraters;
+          *frequency_noise_parameters;
       *complete_execution_phase_two_request_1
            .mutable_partial_composite_el_gamal_public_key() =
           duchy_2_3_composite_public_key_;
@@ -444,9 +444,9 @@ class TestData {
     complete_execution_phase_two_request_2.set_curve_id(kTestCurveId);
     complete_execution_phase_two_request_2.set_flag_count_tuples(
         complete_execution_phase_two_response_1.flag_count_tuples());
-    if (frequency_noise_paraters != nullptr) {
+    if (frequency_noise_parameters != nullptr) {
       *complete_execution_phase_two_request_2.mutable_noise_parameters() =
-          *frequency_noise_paraters;
+          *frequency_noise_parameters;
       *complete_execution_phase_two_request_2
            .mutable_partial_composite_el_gamal_public_key() =
           duchy_3_el_gamal_key_pair_.public_key();
@@ -478,12 +478,16 @@ class TestData {
         ->set_size(kLiquidLegionsSize);
     if (reach_noise_parameters != nullptr) {
       complete_execution_phase_two_at_aggregator_request
-          .mutable_noise_baseline()
+          .mutable_reach_dp_noise_baseline()
           ->set_contributors_count(3);
       *complete_execution_phase_two_at_aggregator_request
-           .mutable_noise_baseline()
+           .mutable_reach_dp_noise_baseline()
            ->mutable_global_reach_dp_noise() =
           reach_noise_parameters->dp_params().global_reach_dp_noise();
+    }
+    if (frequency_noise_parameters != nullptr) {
+      *complete_execution_phase_two_at_aggregator_request
+           .mutable_frequency_noise_parameters() = *frequency_noise_parameters;
     }
     complete_execution_phase_two_at_aggregator_request.set_flag_count_tuples(
         complete_execution_phase_two_response_2.flag_count_tuples());
@@ -532,10 +536,10 @@ class TestData {
         .set_same_key_aggregator_matrix(
             complete_execution_phase_three_response_2
                 .same_key_aggregator_matrix());
-    if (frequency_noise_paraters != nullptr) {
+    if (frequency_noise_parameters != nullptr) {
       *complete_execution_phase_three_at_aggregator_request
            .mutable_global_frequency_dp_noise_per_bucket()
-           ->mutable_dp_params() = frequency_noise_paraters->dp_params();
+           ->mutable_dp_params() = frequency_noise_parameters->dp_params();
       complete_execution_phase_three_at_aggregator_request
           .mutable_global_frequency_dp_noise_per_bucket()
           ->set_contributors_count(3);
@@ -793,50 +797,6 @@ TEST(EndToEnd, SumOfCountsShouldBeCappedbyMaxFrequency) {
   EXPECT_NEAR(result.frequency_distribution[kMaxFrequency], 0.5, 0.001);
 }
 
-TEST(EndToEnd, ComnbinedCases) {
-  TestData test_data;
-  Sketch plain_sketch = CreateEmptyLiquidLegionsSketch();
-  // register 1: count = 6
-  // register 2: count = 3
-  // register 3: count = 1+2+3 = 6
-  // register 4: count = 3+4+5 = 12 (capped as kMaxFrequency+1, i.e. 11
-  // register 5: locally destroyed (key=-1), ignored
-  // register 6: destroyed by conflicting keys (601 and 602), ignored
-  // register 7: locally destroyed (key=-1) + normal register, ignored
-  //
-  // final result should be { 3->1/4, 6->2/4, 11->1/4 }
-  AddRegister(&plain_sketch, /*index=*/1, /*key=*/111, /*count=*/6);
-  AddRegister(&plain_sketch, /*index=*/2, /*key=*/222, /*count=*/3);
-  AddRegister(&plain_sketch, /*index=*/3, /*key=*/333, /*count=*/1);
-  AddRegister(&plain_sketch, /*index=*/3, /*key=*/333, /*count=*/2);
-  AddRegister(&plain_sketch, /*index=*/3, /*key=*/333, /*count=*/3);
-  AddRegister(&plain_sketch, /*index=*/4, /*key=*/444, /*count=*/3);
-  AddRegister(&plain_sketch, /*index=*/4, /*key=*/444, /*count=*/4);
-  AddRegister(&plain_sketch, /*index=*/4, /*key=*/444, /*count=*/5);
-  AddRegister(&plain_sketch, /*index=*/5, /*key=*/-1, /*count=*/2);
-  AddRegister(&plain_sketch, /*index=*/6, /*key=*/601, /*count=*/2);
-  AddRegister(&plain_sketch, /*index=*/6, /*key=*/602, /*count=*/2);
-  AddRegister(&plain_sketch, /*index=*/7, /*key=*/-1, /*count=*/2);
-  AddRegister(&plain_sketch, /*index=*/7, /*key=*/777, /*count=*/2);
-
-  std::string encrypted_sketch =
-      test_data.EncryptWithFlaggedKey(plain_sketch).value();
-  ASSERT_OK_AND_ASSIGN(MpcResult result,
-                       test_data.GoThroughEntireMpcProtocol(
-                           encrypted_sketch, /*reach_noise=*/nullptr,
-                           /*frequency_noise=*/nullptr));
-
-  int64_t expected_reach = wfa::estimation::EstimateCardinalityLiquidLegions(
-      kDecayRate, kLiquidLegionsSize, 7);
-
-  EXPECT_EQ(result.reach, expected_reach);
-
-  ASSERT_THAT(result.frequency_distribution, SizeIs(3));
-  EXPECT_NEAR(result.frequency_distribution[3], 0.25, 0.001);
-  EXPECT_NEAR(result.frequency_distribution[6], 0.5, 0.001);
-  EXPECT_NEAR(result.frequency_distribution[kMaxFrequency], 0.25, 0.001);
-}
-
 TEST(ReachEstimation, NonDpNoiseShouldNotImpactTheResult) {
   TestData test_data;
   Sketch plain_sketch = CreateEmptyLiquidLegionsSketch();
@@ -1092,6 +1052,79 @@ TEST(FrequencyNoise, NonDeterministicNoiseShouldRandomizeTheResult) {
     total_p += x.second;
   }
   EXPECT_NEAR(total_p, 1, 0.0001);
+}
+
+TEST(EndToEnd, CombinedCasesWithDeterministicReachAndFrequencyDpNoises) {
+  TestData test_data;
+  Sketch plain_sketch = CreateEmptyLiquidLegionsSketch();
+  // register 1: count = 6
+  // register 2: count = 3
+  // register 3: count = 1+2+3 = 6
+  // register 4: count = 3+4+5 = 12 (capped as kMaxFrequency+1, i.e. 11
+  // register 5: locally destroyed (key=-1), ignored
+  // register 6: destroyed by conflicting keys (601 and 602), ignored
+  // register 7: locally destroyed (key=-1) + normal register, ignored
+  //
+  // final result should be { 3->1/4, 6->2/4, 11->1/4 }
+  AddRegister(&plain_sketch, /*index=*/1, /*key=*/111, /*count=*/6);
+  AddRegister(&plain_sketch, /*index=*/2, /*key=*/222, /*count=*/3);
+  AddRegister(&plain_sketch, /*index=*/3, /*key=*/333, /*count=*/1);
+  AddRegister(&plain_sketch, /*index=*/3, /*key=*/333, /*count=*/2);
+  AddRegister(&plain_sketch, /*index=*/3, /*key=*/333, /*count=*/3);
+  AddRegister(&plain_sketch, /*index=*/4, /*key=*/444, /*count=*/3);
+  AddRegister(&plain_sketch, /*index=*/4, /*key=*/444, /*count=*/4);
+  AddRegister(&plain_sketch, /*index=*/4, /*key=*/444, /*count=*/5);
+  AddRegister(&plain_sketch, /*index=*/5, /*key=*/-1, /*count=*/2);
+  AddRegister(&plain_sketch, /*index=*/6, /*key=*/601, /*count=*/2);
+  AddRegister(&plain_sketch, /*index=*/6, /*key=*/602, /*count=*/2);
+  AddRegister(&plain_sketch, /*index=*/7, /*key=*/-1, /*count=*/2);
+  AddRegister(&plain_sketch, /*index=*/7, /*key=*/777, /*count=*/2);
+
+  std::string encrypted_sketch =
+      test_data.EncryptWithFlaggedKey(plain_sketch).value();
+
+  RegisterNoiseGenerationParameters reach_noise_parameters;
+  reach_noise_parameters.set_curve_id(kTestCurveId);
+  reach_noise_parameters.set_total_sketches_count(3);
+  reach_noise_parameters.set_contributors_count(kNumOfWorkers);
+  // resulted p = 0.716531, offset = 15.
+  // Random blind histogram noise.
+  *reach_noise_parameters.mutable_dp_params()->mutable_blind_histogram() =
+      NewDifferentialPrivacyParams(1, 1);
+  // resulted p = 0.716531, offset = 10.
+  // Random noise for publisher noise.
+  *reach_noise_parameters.mutable_dp_params()
+       ->mutable_noise_for_publisher_noise() =
+      NewDifferentialPrivacyParams(1, 1);
+  // resulted p ~= 0 , offset = 3.
+  // Deterministic reach dp noise.
+  *reach_noise_parameters.mutable_dp_params()->mutable_global_reach_dp_noise() =
+      NewDifferentialPrivacyParams(40, std::exp(-80));
+  *reach_noise_parameters.mutable_composite_el_gamal_public_key() =
+      test_data.client_el_gamal_public_key_;
+
+  FlagCountTupleNoiseGenerationParameters frequency_noise_params;
+  frequency_noise_params.set_maximum_frequency(kMaxFrequency);
+  frequency_noise_params.set_contributors_count(kNumOfWorkers);
+  // resulted p ~= 0, offset = 5, such that the number of frequency DP noise is
+  // almost a constant, and thus the result is deterministic.
+  *frequency_noise_params.mutable_dp_params() =
+      NewDifferentialPrivacyParams(40, std::exp(-80));
+
+  ASSERT_OK_AND_ASSIGN(
+      MpcResult result,
+      test_data.GoThroughEntireMpcProtocol(
+          encrypted_sketch, &reach_noise_parameters, &frequency_noise_params));
+
+  int64_t expected_reach = wfa::estimation::EstimateCardinalityLiquidLegions(
+      kDecayRate, kLiquidLegionsSize, 7);
+
+  EXPECT_EQ(result.reach, expected_reach);
+
+  ASSERT_THAT(result.frequency_distribution, SizeIs(3));
+  EXPECT_NEAR(result.frequency_distribution[3], 0.25, 0.001);
+  EXPECT_NEAR(result.frequency_distribution[6], 0.5, 0.001);
+  EXPECT_NEAR(result.frequency_distribution[kMaxFrequency], 0.25, 0.001);
 }
 
 }  // namespace

--- a/cross-media-measurement/src/test/cc/wfa/measurement/common/crypto/liquid_legions_v2_encryption_utility_test.cc
+++ b/cross-media-measurement/src/test/cc/wfa/measurement/common/crypto/liquid_legions_v2_encryption_utility_test.cc
@@ -43,6 +43,9 @@ using ::private_join_and_compute::ECCommutativeCipher;
 using ::private_join_and_compute::ECGroup;
 using ::private_join_and_compute::ECPoint;
 using ::testing::SizeIs;
+using ::testing::UnorderedElementsAre;
+using ::testing::Pair;
+using ::testing::DoubleNear;
 using ::wfa::measurement::api::v1alpha::Sketch;
 using ::wfa::measurement::api::v1alpha::SketchConfig;
 
@@ -91,7 +94,7 @@ Sketch CreateEmptyLiquidLegionsSketch() {
   return plain_sketch;
 }
 
-DifferentialPrivacyParams NewDifferentialPrivacyParams(double epsilon,
+DifferentialPrivacyParams MakeDifferentialPrivacyParams(double epsilon,
                                                        double delta) {
   DifferentialPrivacyParams params;
   params.set_epsilon(epsilon);
@@ -590,13 +593,13 @@ TEST(CompleteSetupPhase, NoiseSumAndMeanShouldBeCorrect) {
   *noise_parameters->mutable_composite_el_gamal_public_key() = public_key;
   // resulted p ~= 0 , offset = 7
   *noise_parameters->mutable_dp_params()->mutable_blind_histogram() =
-      NewDifferentialPrivacyParams(40, std::exp(-80));
+      MakeDifferentialPrivacyParams(40, std::exp(-80));
   // resulted p ~= 0 , offset = 4
   *noise_parameters->mutable_dp_params()->mutable_noise_for_publisher_noise() =
-      NewDifferentialPrivacyParams(40, std::exp(-40));
+      MakeDifferentialPrivacyParams(40, std::exp(-40));
   // resulted p ~= 0 , offset = 3
   *noise_parameters->mutable_dp_params()->mutable_global_reach_dp_noise() =
-      NewDifferentialPrivacyParams(40, std::exp(-80));
+      MakeDifferentialPrivacyParams(40, std::exp(-80));
 
   ASSERT_OK_AND_ASSIGN(CompleteSetupPhaseResponse response,
                        CompleteSetupPhase(request));
@@ -814,16 +817,16 @@ TEST(ReachEstimation, NonDpNoiseShouldNotImpactTheResult) {
   // resulted p = 0.716531, offset = 15.
   // Random blind histogram noise.
   *reach_noise_parameters.mutable_dp_params()->mutable_blind_histogram() =
-      NewDifferentialPrivacyParams(1, 1);
+      MakeDifferentialPrivacyParams(1, 1);
   // resulted p = 0.716531, offset = 10.
   // Random noise for publisher noise.
   *reach_noise_parameters.mutable_dp_params()
        ->mutable_noise_for_publisher_noise() =
-      NewDifferentialPrivacyParams(1, 1);
+      MakeDifferentialPrivacyParams(1, 1);
   // resulted p ~= 0 , offset = 3.
   // Deterministic reach dp noise.
   *reach_noise_parameters.mutable_dp_params()->mutable_global_reach_dp_noise() =
-      NewDifferentialPrivacyParams(40, std::exp(-80));
+      MakeDifferentialPrivacyParams(40, std::exp(-80));
   *reach_noise_parameters.mutable_composite_el_gamal_public_key() =
       test_data.client_el_gamal_public_key_;
 
@@ -857,7 +860,7 @@ TEST(FrequencyNoise, TotalNoiseBytesShouldBeCorrect) {
   frequency_noise_params.set_contributors_count(kNumOfWorkers);
   // resulted p = 0.606531, offset = 4
   *frequency_noise_params.mutable_dp_params() =
-      NewDifferentialPrivacyParams(1, 50);
+      MakeDifferentialPrivacyParams(1, 50);
 
   int computed_offset = 4;
   int64_t expected_total_noise_tuple_count =
@@ -936,7 +939,7 @@ TEST(FrequencyNoise, AllFrequencyBucketsShouldHaveNoise) {
   frequency_noise_params.set_contributors_count(kNumOfWorkers);
   // resulted p = 0.606531, offset = 12
   *frequency_noise_params.mutable_dp_params() =
-      NewDifferentialPrivacyParams(1, 1);
+      MakeDifferentialPrivacyParams(1, 1);
 
   int computed_offset = 12;
   int64_t expected_total_noise_tuple_count =
@@ -1007,7 +1010,7 @@ TEST(FrequencyNoise, DeterministicNoiseShouldHaveNoImpact) {
   // resulted p ~= 0, offset = 5, such that the number of frequency DP noise is
   // almost a constant, and thus the result is deterministic.
   *frequency_noise_params.mutable_dp_params() =
-      NewDifferentialPrivacyParams(40, std::exp(-80));
+      MakeDifferentialPrivacyParams(40, std::exp(-80));
 
   ASSERT_OK_AND_ASSIGN(
       MpcResult result,
@@ -1035,7 +1038,7 @@ TEST(FrequencyNoise, NonDeterministicNoiseShouldRandomizeTheResult) {
   frequency_noise_params.set_contributors_count(kNumOfWorkers);
   // resulted p = 0.606531, offset = 12
   *frequency_noise_params.mutable_dp_params() =
-      NewDifferentialPrivacyParams(1, 1);
+      MakeDifferentialPrivacyParams(1, 1);
 
   ASSERT_OK_AND_ASSIGN(
       MpcResult result,
@@ -1090,16 +1093,16 @@ TEST(EndToEnd, CombinedCasesWithDeterministicReachAndFrequencyDpNoises) {
   // resulted p = 0.716531, offset = 15.
   // Random blind histogram noise.
   *reach_noise_parameters.mutable_dp_params()->mutable_blind_histogram() =
-      NewDifferentialPrivacyParams(1, 1);
+      MakeDifferentialPrivacyParams(1, 1);
   // resulted p = 0.716531, offset = 10.
   // Random noise for publisher noise.
   *reach_noise_parameters.mutable_dp_params()
        ->mutable_noise_for_publisher_noise() =
-      NewDifferentialPrivacyParams(1, 1);
+      MakeDifferentialPrivacyParams(1, 1);
   // resulted p ~= 0 , offset = 3.
   // Deterministic reach dp noise.
   *reach_noise_parameters.mutable_dp_params()->mutable_global_reach_dp_noise() =
-      NewDifferentialPrivacyParams(40, std::exp(-80));
+      MakeDifferentialPrivacyParams(40, std::exp(-80));
   *reach_noise_parameters.mutable_composite_el_gamal_public_key() =
       test_data.client_el_gamal_public_key_;
 
@@ -1109,7 +1112,7 @@ TEST(EndToEnd, CombinedCasesWithDeterministicReachAndFrequencyDpNoises) {
   // resulted p ~= 0, offset = 5, such that the number of frequency DP noise is
   // almost a constant, and thus the result is deterministic.
   *frequency_noise_params.mutable_dp_params() =
-      NewDifferentialPrivacyParams(40, std::exp(-80));
+      MakeDifferentialPrivacyParams(40, std::exp(-80));
 
   ASSERT_OK_AND_ASSIGN(
       MpcResult result,
@@ -1120,6 +1123,13 @@ TEST(EndToEnd, CombinedCasesWithDeterministicReachAndFrequencyDpNoises) {
       kDecayRate, kLiquidLegionsSize, 7);
 
   EXPECT_EQ(result.reach, expected_reach);
+
+EXPECT_THAT(
+  result.frequency_distribution,
+  UnorderedElementsAre(
+    Pair(3, DoubleNear(0.25, 0.001)),
+    Pair(6, DoubleNear(0.5, 0.001)),
+    Pair(kMaxFrequency,DoubleNear(0.25, 0.001))));
 
   ASSERT_THAT(result.frequency_distribution, SizeIs(3));
   EXPECT_NEAR(result.frequency_distribution[3], 0.25, 0.001);

--- a/cross-media-measurement/src/test/cc/wfa/measurement/common/crypto/liquid_legions_v2_encryption_utility_test.cc
+++ b/cross-media-measurement/src/test/cc/wfa/measurement/common/crypto/liquid_legions_v2_encryption_utility_test.cc
@@ -42,10 +42,10 @@ using ::private_join_and_compute::Context;
 using ::private_join_and_compute::ECCommutativeCipher;
 using ::private_join_and_compute::ECGroup;
 using ::private_join_and_compute::ECPoint;
+using ::testing::DoubleNear;
+using ::testing::Pair;
 using ::testing::SizeIs;
 using ::testing::UnorderedElementsAre;
-using ::testing::Pair;
-using ::testing::DoubleNear;
 using ::wfa::measurement::api::v1alpha::Sketch;
 using ::wfa::measurement::api::v1alpha::SketchConfig;
 
@@ -95,7 +95,7 @@ Sketch CreateEmptyLiquidLegionsSketch() {
 }
 
 DifferentialPrivacyParams MakeDifferentialPrivacyParams(double epsilon,
-                                                       double delta) {
+                                                        double delta) {
   DifferentialPrivacyParams params;
   params.set_epsilon(epsilon);
   params.set_delta(delta);
@@ -1124,17 +1124,11 @@ TEST(EndToEnd, CombinedCasesWithDeterministicReachAndFrequencyDpNoises) {
 
   EXPECT_EQ(result.reach, expected_reach);
 
-EXPECT_THAT(
-  result.frequency_distribution,
-  UnorderedElementsAre(
-    Pair(3, DoubleNear(0.25, 0.001)),
-    Pair(6, DoubleNear(0.5, 0.001)),
-    Pair(kMaxFrequency,DoubleNear(0.25, 0.001))));
-
-  ASSERT_THAT(result.frequency_distribution, SizeIs(3));
-  EXPECT_NEAR(result.frequency_distribution[3], 0.25, 0.001);
-  EXPECT_NEAR(result.frequency_distribution[6], 0.5, 0.001);
-  EXPECT_NEAR(result.frequency_distribution[kMaxFrequency], 0.25, 0.001);
+  EXPECT_THAT(
+      result.frequency_distribution,
+      UnorderedElementsAre(Pair(3, DoubleNear(0.25, 0.001)),
+                           Pair(6, DoubleNear(0.5, 0.001)),
+                           Pair(kMaxFrequency, DoubleNear(0.25, 0.001))));
 }
 
 }  // namespace

--- a/cross-media-measurement/src/test/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv2/LiquidLegionsV2MillTest.kt
+++ b/cross-media-measurement/src/test/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv2/LiquidLegionsV2MillTest.kt
@@ -1120,9 +1120,14 @@ class LiquidLegionsV2MillTest {
           decayRate = 12.0
           size = 10_000_000L
         }
-        noiseBaselineBuilder.apply {
+        reachDpNoiseBaselineBuilder.apply {
           contributorsCount = WORKER_COUNT
           globalReachDpNoise = testNoiseConfig.reachNoiseConfig.globalReachDpNoise
+        }
+        frequencyNoiseParametersBuilder.apply {
+          contributorsCount = WORKER_COUNT
+          maximumFrequency = MAX_FREQUENCY
+          dpParams = testNoiseConfig.frequencyNoiseConfig
         }
       }.build()
     )


### PR DESCRIPTION
1. The frequency noise was not subtracted from the number of active
registers before estimating reach, which causes an error.
2. Updated unit test and integration test to add both reach and frequency
noises.
3. Adopted some clang suggestions.