### PR TITLE
Move custom Java base image to Docker Hub

### DIFF
--- a/cross-media-measurement/WORKSPACE
+++ b/cross-media-measurement/WORKSPACE
@@ -214,9 +214,9 @@ container_pull(
 # See //src/main/docker/base:push_java_base
 container_pull(
     name = "debian_java_base",
-    digest = "sha256:e2d6a9216a49e4c909690a1f98d4670aa503d6a3fe5d6f1f9a171eadb45e23e5",
-    registry = "gcr.io",
-    repository = "ads-open-measurement/java-base",
+    digest = "sha256:c6746729103a1a306a1ed572012562496512a691b3b23c3abacd64ad503cebc2",
+    registry = "docker.io",
+    repository = "wfameasurement/java-base",
 )
 
 # APT key for Google cloud.

--- a/cross-media-measurement/WORKSPACE
+++ b/cross-media-measurement/WORKSPACE
@@ -190,7 +190,7 @@ load("@io_bazel_rules_docker//container:container.bzl", "container_pull")
 # docker.io/debian:bullseye-slim
 container_pull(
     name = "debian_bullseye",
-    digest = "sha256:d92a89b71e6adc50535710f53c78bb5bc84f80549e48342856bb2cc6c87e4f2a",
+    digest = "sha256:8ab4e348f60ebd18b891593a531ded31cbbc3878f6e476116f3b49b15c199110",
     registry = "docker.io",
     repository = "debian",
 )

--- a/cross-media-measurement/src/main/docker/base/BUILD.bazel
+++ b/cross-media-measurement/src/main/docker/base/BUILD.bazel
@@ -1,43 +1,53 @@
 # Base images.
 load("//src/main/docker:constants.bzl", "DEBIAN_JAVA_11")
-load("@io_bazel_rules_docker//container:container.bzl", "container_image", "container_push")
-load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "download_pkgs")
-load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
+load(
+    "//src/main/docker:defs.bzl",
+    "container_commit_install_apt_packages",
+)
+load(
+    "@io_bazel_rules_docker//container:container.bzl",
+    "container_image",
+    "container_layer",
+    "container_push",
+)
 
 JAVA = DEBIAN_JAVA_11
 
-download_pkgs(
-    name = "packages",
-    image_tar = "@debian_bullseye//image",
-    packages = [
-        "openjdk-11-jre-headless",
+BASE_IMAGE = "@debian_bullseye//image"
+
+container_layer(
+    name = "man_directories",
+    empty_dirs = [
+        "/usr/share/man/man1",
+        "/usr/share/man/man2",
     ],
-    tags = [
-        "manual",
-        "no-remote-exec",
-        "requires-network",
-    ],
+    tags = ["manual"],
 )
 
-install_pkgs(
-    name = "packages_image",
-    image_tar = "@debian_bullseye//image",
-    installables_tar = ":packages.tar",
-    output_image_name = "packages_image",
-    tags = [
-        "manual",
-        "no-remote-exec",
-    ],
+container_image(
+    name = "man_directories_image",
+    base = BASE_IMAGE,
+    layers = [":man_directories"],
+    tags = ["manual"],
+)
+
+container_commit_install_apt_packages(
+    name = "apt_packages",
+    image = ":man_directories_image.tar",
+    packages = ["openjdk-11-jre-headless"],
+    tags = ["manual"],
+    upgrade = True,
 )
 
 container_image(
     name = "java_base",
-    base = ":packages_image.tar",
+    base = BASE_IMAGE,
     entrypoint = [
         JAVA.bin + "/java",
         "-jar",
     ],
     env = JAVA.env,
+    layers = [":apt_packages"],
     symlinks = {"/usr/bin/java": JAVA.bin + "/java"},
     tags = ["manual"],
 )

--- a/cross-media-measurement/src/main/docker/base/BUILD.bazel
+++ b/cross-media-measurement/src/main/docker/base/BUILD.bazel
@@ -56,7 +56,7 @@ container_push(
     name = "push_java_base",
     format = "Docker",
     image = ":java_base",
-    registry = "gcr.io",
-    repository = "ads-open-measurement/java-base",
+    registry = "docker.io",
+    repository = "wfameasurement/java-base",
     tags = ["manual"],
 )


### PR DESCRIPTION
This moves the image from a private Google Container Registry to the `wfameasurement` Docker Hub organization.