### PR TITLE
Measurement API tagging

### DIFF
--- a/cross-media-measurement-api/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
+++ b/cross-media-measurement-api/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
@@ -105,6 +105,7 @@ proto_library(
     strip_import_prefix = IMPORT_PREFIX,
     deps = [
         ":measurement_proto",
+        ":measurement_consumer_proto",
     ],
 )
 

--- a/cross-media-measurement-api/src/main/proto/wfa/measurement/api/v2alpha/measurement.proto
+++ b/cross-media-measurement-api/src/main/proto/wfa/measurement/api/v2alpha/measurement.proto
@@ -149,6 +149,9 @@ message Measurement {
   bytes encrypted_result = 11;
 
   // List of key value pair tags for this `Measurement`.
+  // These are to enable `Measurement` Consumers to apply labels to the
+  // `Measurement` to aid in filtering and identifying later on.
+  // Do not put sensitive data in this field.
   map<string, string> tags = 12;
 }
 

--- a/cross-media-measurement-api/src/main/proto/wfa/measurement/api/v2alpha/measurement.proto
+++ b/cross-media-measurement-api/src/main/proto/wfa/measurement/api/v2alpha/measurement.proto
@@ -148,8 +148,8 @@ message Measurement {
   // `result_public_key`.
   bytes encrypted_result = 11;
 
-  // List of key value pair tags for this `Measurement`.
-  // These are to enable `Measurement` Consumers to apply labels to the
+  // Map of caller-defined tag keys to values for this `Measurement`.
+  // These are to enable `MeasurementConsumer`s to apply labels to the
   // `Measurement` to aid in filtering and identifying later on.
   // Do not put sensitive data in this field.
   map<string, string> tags = 12;

--- a/cross-media-measurement-api/src/main/proto/wfa/measurement/api/v2alpha/measurement.proto
+++ b/cross-media-measurement-api/src/main/proto/wfa/measurement/api/v2alpha/measurement.proto
@@ -147,6 +147,9 @@ message Measurement {
   // between `measurement_public_key` in `measurement_spec` and
   // `result_public_key`.
   bytes encrypted_result = 11;
+
+  // List of key value pair tags for this `Measurement`.
+  map<string, string> tags = 12;
 }
 
 // Specification for a `Measurement`. Immutable.

--- a/cross-media-measurement-api/src/main/proto/wfa/measurement/api/v2alpha/measurements_service.proto
+++ b/cross-media-measurement-api/src/main/proto/wfa/measurement/api/v2alpha/measurements_service.proto
@@ -31,6 +31,10 @@ service Measurements {
   // Creates (registers) a `Measurement`.
   rpc CreateMeasurement(CreateMeasurementRequest)
       returns (Measurement) {}
+
+  // Lists `Measurement`s fiting provided filters.
+  rpc ListMeasurements(ListMeasurementsRequest)
+      returns (ListMeasurementsResponse) {}
 }
 
 // Request message for `GetMeasurement` method.
@@ -45,4 +49,14 @@ message CreateMeasurementRequest {
   // ignored, and the system will assign an ID.
   Measurement measurement = 1;
 }
+
+// Request message for `ListMeasurements` method.
+message ListMeasurementsRequest {
+    //TODO(uakyol): fill this proto
+}
+
+message ListMeasurementsResponse {
+  //TODO(uakyol): fill this proto
+}
+
 

--- a/cross-media-measurement-api/src/main/proto/wfa/measurement/api/v2alpha/measurements_service.proto
+++ b/cross-media-measurement-api/src/main/proto/wfa/measurement/api/v2alpha/measurements_service.proto
@@ -33,7 +33,7 @@ service Measurements {
   rpc CreateMeasurement(CreateMeasurementRequest)
       returns (Measurement) {}
 
-  // Lists `Measurement`s fiting provided tags.
+  // Lists `Measurement`s for the parent `MeasurementConsumer`.
   rpc ListMeasurements(ListMeasurementsRequest)
       returns (ListMeasurementsResponse) {}
 }
@@ -76,7 +76,7 @@ message ListMeasurementsRequest {
     // TODO(uakyol): extend this to cover all predicate logic.
     map<string, string> tags = 1;
   }
-  
+
   Filter filter = 4;
 }
 

--- a/cross-media-measurement-api/src/main/proto/wfa/measurement/api/v2alpha/measurements_service.proto
+++ b/cross-media-measurement-api/src/main/proto/wfa/measurement/api/v2alpha/measurements_service.proto
@@ -32,7 +32,7 @@ service Measurements {
   rpc CreateMeasurement(CreateMeasurementRequest)
       returns (Measurement) {}
 
-  // Lists `Measurement`s fiting provided filters.
+  // Lists `Measurement`s fiting provided tags.
   rpc ListMeasurements(ListMeasurementsRequest)
       returns (ListMeasurementsResponse) {}
 }
@@ -52,11 +52,19 @@ message CreateMeasurementRequest {
 
 // Request message for `ListMeasurements` method.
 message ListMeasurementsRequest {
-    //TODO(uakyol): fill this proto
+  // ID of the parent `MeasurementConsumer`.
+  string measurement_consumer_id = 1;
+  // List of key value pair tags to retrieve `Measurement`s by.
+  // `Measurement`s with tags that have all of the tags specified here
+  // are retrieved.
+  // TODO(uakyol): extend this to cover all predicate logic.
+  map<string, string> tags = 2;
 }
 
 message ListMeasurementsResponse {
-  //TODO(uakyol): fill this proto
+  // List of `Measurement`s that has all of the tags in the
+  // ListMeasurementsRequest
+  repeated Measurement measurement = 1;
 }
 
 

--- a/cross-media-measurement-api/src/main/proto/wfa/measurement/api/v2alpha/measurements_service.proto
+++ b/cross-media-measurement-api/src/main/proto/wfa/measurement/api/v2alpha/measurements_service.proto
@@ -53,7 +53,7 @@ message CreateMeasurementRequest {
 
 // Request message for `ListMeasurements` method.
 message ListMeasurementsRequest {
-  // ID of the parent `MeasurementConsumer`.
+  // Resource key of the parent `MeasurementConsumer`.
   MeasurementConsumer.Key parent = 1;
 
   // The maximum number of `Measurement`s to return.
@@ -70,10 +70,9 @@ message ListMeasurementsRequest {
   string page_token = 3;
 
   message Filter {
-    // List of key value pair tags to retrieve `Measurement`s by.
+    // Map of key value pair tags to retrieve `Measurement`s by.
     // `Measurement`s with tags that have all of the tags specified here
     // are retrieved.
-    // TODO(uakyol): extend this to cover all predicate logic.
     map<string, string> tags = 1;
   }
 

--- a/cross-media-measurement-api/src/main/proto/wfa/measurement/api/v2alpha/measurements_service.proto
+++ b/cross-media-measurement-api/src/main/proto/wfa/measurement/api/v2alpha/measurements_service.proto
@@ -17,6 +17,7 @@ syntax = "proto3";
 package wfa.measurement.api.v2alpha;
 
 import "wfa/measurement/api/v2alpha/measurement.proto";
+import "wfa/measurement/api/v2alpha/measurement_consumer.proto";
 
 option java_package = "org.wfanet.measurement.api.v2alpha";
 option java_multiple_files = true;
@@ -53,18 +54,34 @@ message CreateMeasurementRequest {
 // Request message for `ListMeasurements` method.
 message ListMeasurementsRequest {
   // ID of the parent `MeasurementConsumer`.
-  string measurement_consumer_id = 1;
+  MeasurementConsumer.Key parent = 1;
+
+  // The maximum number of `Measurement`s to return.
+  // The service may return fewer than this value.
+  // If unspecified, at most 50 `Measurement`s will be returned.
+  // The maximum value is 1000; values above 1000 will be coerced to 1000.
+  int32 page_size = 2;
+
+  // A page token, received from a previous `ListMeasurementsRequest` call.
+  // Provide this to retrieve the subsequent page.
+  //
+  // When paginating, all other parameters provided to `ListMeasurementsRequest`
+  // must match the call that provided the page token.
+  string page_token = 3;
   // List of key value pair tags to retrieve `Measurement`s by.
   // `Measurement`s with tags that have all of the tags specified here
   // are retrieved.
   // TODO(uakyol): extend this to cover all predicate logic.
-  map<string, string> tags = 2;
+  map<string, string> tags = 4;
 }
 
 message ListMeasurementsResponse {
   // List of `Measurement`s that has all of the tags in the
   // ListMeasurementsRequest
   repeated Measurement measurement = 1;
+  // A token, which can be sent as `page_token` to retrieve the next page.
+  // If this field is omitted, there are no subsequent pages.
+  string next_page_token = 2;
 }
 
 

--- a/cross-media-measurement-api/src/main/proto/wfa/measurement/api/v2alpha/measurements_service.proto
+++ b/cross-media-measurement-api/src/main/proto/wfa/measurement/api/v2alpha/measurements_service.proto
@@ -68,11 +68,16 @@ message ListMeasurementsRequest {
   // When paginating, all other parameters provided to `ListMeasurementsRequest`
   // must match the call that provided the page token.
   string page_token = 3;
-  // List of key value pair tags to retrieve `Measurement`s by.
-  // `Measurement`s with tags that have all of the tags specified here
-  // are retrieved.
-  // TODO(uakyol): extend this to cover all predicate logic.
-  map<string, string> tags = 4;
+
+  message Filter {
+    // List of key value pair tags to retrieve `Measurement`s by.
+    // `Measurement`s with tags that have all of the tags specified here
+    // are retrieved.
+    // TODO(uakyol): extend this to cover all predicate logic.
+    map<string, string> tags = 1;
+  }
+  
+  Filter filter = 4;
 }
 
 message ListMeasurementsResponse {


### PR DESCRIPTION
Adding tagging logic for measurements.

Tags are string key value pairs that can be used in api calls to the Kingdom to retrieve measurements that have all the requested tags in a request. Predicate logic which will include arbitrary conditions can be added in a followup PR.