### PR TITLE
Clean up naming in HelloStreaming service.

### DIFF
--- a/examples/src/main/kotlin/org/wfanet/examples/streaming/HelloStreamingClient.kt
+++ b/examples/src/main/kotlin/org/wfanet/examples/streaming/HelloStreamingClient.kt
@@ -27,11 +27,11 @@ import org.wfanet.examples.streaming.HelloStreamingGrpcKt.HelloStreamingCoroutin
 class HelloStreamingClient(private val channel: ManagedChannel) : Closeable {
   private val stub = HelloStreamingCoroutineStub(channel)
 
-  suspend fun helloStreaming(names: Array<String>) {
-    val requests = names.map { name -> HelloStreamingRequest.newBuilder().setName(name).build() }
+  suspend fun sayHelloStreaming(vararg names: String) {
+    val requests = names.map { name -> SayHelloStreamingRequest.newBuilder().setName(name).build() }
       .asFlow()
       .onEach { request -> println("Sending: ${request.name}") }
-    val response = stub.helloStreaming(requests)
+    val response = stub.sayHelloStreaming(requests)
     response.messageList.forEach { message ->
       println("Received: $message")
     }
@@ -49,6 +49,6 @@ suspend fun main(args: Array<String>) {
   val port = 50051
   val channel = ManagedChannelBuilder.forAddress("localhost", port).usePlaintext().build()
   HelloStreamingClient(channel).use { client ->
-    client.helloStreaming(arrayOf("Alice", "Bob", "Carol"))
+    client.sayHelloStreaming("Alice", "Bob", "Carol")
   }
 }

--- a/examples/src/main/kotlin/org/wfanet/examples/streaming/HelloStreamingClient.kt
+++ b/examples/src/main/kotlin/org/wfanet/examples/streaming/HelloStreamingClient.kt
@@ -22,10 +22,10 @@ import java.io.Closeable
 import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.onEach
-import org.wfanet.examples.streaming.HelloStreamingServiceGrpcKt.HelloStreamingServiceCoroutineStub
+import org.wfanet.examples.streaming.HelloStreamingGrpcKt.HelloStreamingCoroutineStub
 
 class HelloStreamingClient(private val channel: ManagedChannel) : Closeable {
-  private val stub = HelloStreamingServiceCoroutineStub(channel)
+  private val stub = HelloStreamingCoroutineStub(channel)
 
   suspend fun helloStreaming(names: Array<String>) {
     val requests = names.map { name -> HelloStreamingRequest.newBuilder().setName(name).build() }

--- a/examples/src/main/kotlin/org/wfanet/examples/streaming/HelloStreamingServer.kt
+++ b/examples/src/main/kotlin/org/wfanet/examples/streaming/HelloStreamingServer.kt
@@ -20,7 +20,7 @@ import io.grpc.Server
 import io.grpc.ServerBuilder
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collect
-import org.wfanet.examples.streaming.HelloStreamingServiceGrpcKt.HelloStreamingServiceCoroutineImplBase
+import org.wfanet.examples.streaming.HelloStreamingGrpcKt.HelloStreamingCoroutineImplBase
 
 class HelloStreamingServer(private val port: Int) {
   val server: Server = ServerBuilder
@@ -48,8 +48,7 @@ class HelloStreamingServer(private val port: Int) {
     server.awaitTermination()
   }
 
-  private class HelloStreamingService :
-    HelloStreamingServiceCoroutineImplBase() {
+  private class HelloStreamingService : HelloStreamingCoroutineImplBase() {
     override suspend fun helloStreaming(
       requests: Flow<HelloStreamingRequest>
     ): HelloStreamingResponse {

--- a/examples/src/main/kotlin/org/wfanet/examples/streaming/HelloStreamingServer.kt
+++ b/examples/src/main/kotlin/org/wfanet/examples/streaming/HelloStreamingServer.kt
@@ -49,10 +49,10 @@ class HelloStreamingServer(private val port: Int) {
   }
 
   private class HelloStreamingService : HelloStreamingCoroutineImplBase() {
-    override suspend fun helloStreaming(
-      requests: Flow<HelloStreamingRequest>
-    ): HelloStreamingResponse {
-      val responseBuilder = HelloStreamingResponse.newBuilder()
+    override suspend fun sayHelloStreaming(
+      requests: Flow<SayHelloStreamingRequest>
+    ): SayHelloStreamingResponse {
+      val responseBuilder = SayHelloStreamingResponse.newBuilder()
       requests.collect { request ->
         println("Received: ${request.name}")
         responseBuilder

--- a/examples/src/main/proto/wfa/examples/streaming/hello_streaming_service.proto
+++ b/examples/src/main/proto/wfa/examples/streaming/hello_streaming_service.proto
@@ -19,8 +19,9 @@ package wfa.examples.streaming;
 option java_package = "org.wfanet.examples.streaming";
 option java_multiple_files = true;
 
-service HelloStreamingService {
-  rpc HelloStreaming(stream HelloStreamingRequest) returns (HelloStreamingResponse) {}
+service HelloStreaming {
+  rpc HelloStreaming(stream HelloStreamingRequest)
+      returns (HelloStreamingResponse) {}
 }
 
 message HelloStreamingRequest {

--- a/examples/src/main/proto/wfa/examples/streaming/hello_streaming_service.proto
+++ b/examples/src/main/proto/wfa/examples/streaming/hello_streaming_service.proto
@@ -20,14 +20,14 @@ option java_package = "org.wfanet.examples.streaming";
 option java_multiple_files = true;
 
 service HelloStreaming {
-  rpc HelloStreaming(stream HelloStreamingRequest)
-      returns (HelloStreamingResponse) {}
+  rpc SayHelloStreaming(stream SayHelloStreamingRequest)
+      returns (SayHelloStreamingResponse) {}
 }
 
-message HelloStreamingRequest {
+message SayHelloStreamingRequest {
   string name = 1;
 }
 
-message HelloStreamingResponse {
+message SayHelloStreamingResponse {
   repeated string message = 1;
 }


### PR DESCRIPTION
* Remove redundant "Service" suffix from service name.
* Rename `HelloStreaming` method to `SayHelloStreaming`.