### PR TITLE
Several minor updates.

### DIFF
--- a/cross-media-measurement/src/main/kotlin/org/wfanet/measurement/duchy/daemon/mill/MillBase.kt
+++ b/cross-media-measurement/src/main/kotlin/org/wfanet/measurement/duchy/daemon/mill/MillBase.kt
@@ -452,10 +452,10 @@ abstract class MillBase(
   }
 }
 
-const val CRYPTO_LIB_CPU_DURATION = "crypto_lib_cpu_duration"
-const val JNI_WALL_CLOCK_DURATION = "jni_wall_clock_duration"
-const val STAGE_CPU_DURATION = "stage_cpu_duration"
-const val STAGE_WALL_CLOCK_DURATION = "stage_wall_clock_duration"
+const val CRYPTO_LIB_CPU_DURATION = "crypto_lib_cpu_duration_ms"
+const val JNI_WALL_CLOCK_DURATION = "jni_wall_clock_duration_ms"
+const val STAGE_CPU_DURATION = "stage_cpu_duration_ms"
+const val STAGE_WALL_CLOCK_DURATION = "stage_wall_clock_duration_ms"
 const val BYTES_OF_DATA_IN_RPC = "bytes_of_data_in_rpc"
 const val CURRENT_RUNTIME_MEMORY_MAXIMUM = "current_runtime_memory_maximum"
 const val CURRENT_RUNTIME_MEMORY_TOTAL = "current_runtime_memory_total"

--- a/cross-media-measurement/src/main/kotlin/org/wfanet/measurement/loadtest/CorrectnessImpl.kt
+++ b/cross-media-measurement/src/main/kotlin/org/wfanet/measurement/loadtest/CorrectnessImpl.kt
@@ -23,6 +23,7 @@ import java.time.Instant
 import java.util.UUID
 import java.util.logging.Logger
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
@@ -33,6 +34,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.flow.transform
+import kotlinx.coroutines.launch
 import org.wfanet.anysketch.AnySketch
 import org.wfanet.anysketch.SketchProtos
 import org.wfanet.anysketch.crypto.EncryptSketchRequest
@@ -124,8 +126,12 @@ class CorrectnessImpl(
     logger.info("Estimation Results saved with blob key: $storedResultsPath")
 
     // Finally, we are sending encrypted sketches to the PublisherDataService.
-    generatedCampaigns.forEach {
-      encryptAndSend(it, testResult)
+    coroutineScope {
+      generatedCampaigns.forEach {
+        launch {
+          encryptAndSend(it, testResult)
+        }
+      }
     }
 
     val expectedResult =

--- a/cross-media-measurement/src/test/cc/wfa/measurement/common/crypto/BUILD.bazel
+++ b/cross-media-measurement/src/test/cc/wfa/measurement/common/crypto/BUILD.bazel
@@ -19,6 +19,7 @@ cc_test(
 cc_test(
     name = "liquid_legions_v2_encryption_utility_test",
     size = "small",
+    timeout = "moderate",
     srcs = [
         "liquid_legions_v2_encryption_utility_test.cc",
     ],

--- a/cross-media-measurement/src/test/cc/wfa/measurement/common/crypto/liquid_legions_v2_encryption_utility_test.cc
+++ b/cross-media-measurement/src/test/cc/wfa/measurement/common/crypto/liquid_legions_v2_encryption_utility_test.cc
@@ -1034,11 +1034,12 @@ TEST(FrequencyNoise, NonDeterministicNoiseShouldRandomizeTheResult) {
       test_data.EncryptWithFlaggedKey(plain_sketch).value();
 
   FlagCountTupleNoiseGenerationParameters frequency_noise_params;
-  frequency_noise_params.set_maximum_frequency(kMaxFrequency);
+  // Add 30 buckets to reduce flakiness.
+  frequency_noise_params.set_maximum_frequency(30);
   frequency_noise_params.set_contributors_count(kNumOfWorkers);
-  // resulted p = 0.606531, offset = 12
+  // resulted p = 0.606531, offset = 6
   *frequency_noise_params.mutable_dp_params() =
-      MakeDifferentialPrivacyParams(1, 1);
+      MakeDifferentialPrivacyParams(1, 50);
 
   ASSERT_OK_AND_ASSIGN(
       MpcResult result,


### PR DESCRIPTION
1. add "ms" to the duration metric name in the log.
2. parallel encrypt sketch in the correctnessImpl.
3. reduce flakiness of the liquid_legions_v2_encryption_utility_test.