### PR TITLE
Update the GetBlindHistogramNoiseOptions to match the paper.

### DIFF
--- a/cross-media-measurement/src/main/cc/wfa/measurement/common/crypto/noise_parameters_computation.cc
+++ b/cross-media-measurement/src/main/cc/wfa/measurement/common/crypto/noise_parameters_computation.cc
@@ -39,9 +39,9 @@ math::DistributedGeometricRandomComponentOptions GetBlindHistogramNoiseOptions(
     int uncorrupted_party_count) {
   ABSL_ASSERT(publisher_count > 0);
   ABSL_ASSERT(uncorrupted_party_count > 0);
-  double success_ratio = std::exp(-params.epsilon() / 3);
-  int offset = ComputateMuPolya(params.epsilon() / 3, params.delta(),
-                                2 * uncorrupted_party_count * publisher_count);
+  double success_ratio = std::exp(-params.epsilon() / 2);
+  int offset = ComputateMuPolya(params.epsilon() / 2, params.delta(),
+                                uncorrupted_party_count * publisher_count);
   return {
       .num = uncorrupted_party_count,
       .p = success_ratio,

--- a/cross-media-measurement/src/test/cc/wfa/measurement/common/crypto/liquid_legions_v2_encryption_utility_test.cc
+++ b/cross-media-measurement/src/test/cc/wfa/measurement/common/crypto/liquid_legions_v2_encryption_utility_test.cc
@@ -576,7 +576,7 @@ TEST(CompleteSetupPhase, NoiseSumAndMeanShouldBeCorrect) {
 
   int publisher_count = 3;
 
-  int64_t computed_blinded_histogram_noise_offset = 7;
+  int64_t computed_blinded_histogram_noise_offset = 5;
   int64_t computed_publisher_noise_offset = 4;
   int64_t computed_reach_dp_noise_offset = 3;
   int64_t expected_total_register_count =
@@ -591,7 +591,7 @@ TEST(CompleteSetupPhase, NoiseSumAndMeanShouldBeCorrect) {
   noise_parameters->set_total_sketches_count(publisher_count);
   noise_parameters->set_contributors_count(kNumOfWorkers);
   *noise_parameters->mutable_composite_el_gamal_public_key() = public_key;
-  // resulted p ~= 0 , offset = 7
+  // resulted p ~= 0 , offset = 5
   *noise_parameters->mutable_dp_params()->mutable_blind_histogram() =
       MakeDifferentialPrivacyParams(40, std::exp(-80));
   // resulted p ~= 0 , offset = 4

--- a/cross-media-measurement/src/test/cc/wfa/measurement/common/crypto/noise_parameters_computation_test.cc
+++ b/cross-media-measurement/src/test/cc/wfa/measurement/common/crypto/noise_parameters_computation_test.cc
@@ -30,9 +30,9 @@ TEST(GetBlindHistogramNoiseOptions, ExampleResultShouldBeCorrect) {
                                                uncorrupted_party_count);
 
   EXPECT_EQ(options.num, uncorrupted_party_count);
-  EXPECT_NEAR(options.p, 0.988, 0.001);
-  EXPECT_EQ(options.shift_offset, 1697);
-  EXPECT_EQ(options.truncate_threshold, 1697);
+  EXPECT_NEAR(options.p, 0.982, 0.001);
+  EXPECT_EQ(options.shift_offset, 1072);
+  EXPECT_EQ(options.truncate_threshold, 1072);
 }
 
 TEST(GetNoiseForPublisherNoiseOptions, ExampleResultShouldBeCorrect) {


### PR DESCRIPTION
@pasin30055 , please check GetBlindHistogramNoiseOptions() as well as other methods, and make sure they match the latest paper description. Thanks. 