### PR TITLE
Optimize SameKeyAggregation at LLV2 phase one.

### DIFF
--- a/cross-media-measurement/src/main/cc/wfa/measurement/common/crypto/liquid_legions_v2_encryption_utility.cc
+++ b/cross-media-measurement/src/main/cc/wfa/measurement/common/crypto/liquid_legions_v2_encryption_utility.cc
@@ -39,11 +39,15 @@ namespace {
 // to this group, i.e., having the same blinded register index.
 absl::Status MergeCountsUsingSameKeyAggregation(
     absl::Span<const size_t> sub_permutation, absl::string_view registers,
-    ProtocolCryptor& protocol_cryptor, std::string& response) {
+    ProtocolCryptor& protocol_cryptor, int total_sketches_count,
+    std::string& response) {
   if (sub_permutation.empty()) {
     return absl::InternalError("Empty sub permutation.");
   }
-
+  if (sub_permutation.size() > total_sketches_count) {
+    // These are publisher noises or padding noises, skip all or them.
+    return absl::OkStatus();
+  }
   ASSIGN_OR_RETURN(ElGamalEcPointPair destroyed_key_constant_ec_pair,
                    protocol_cryptor.EncryptPlaintextToEcPointsCompositeElGamal(
                        kDestroyedRegisterKey));
@@ -113,7 +117,8 @@ absl::Status MergeCountsUsingSameKeyAggregation(
 absl::Status JoinRegistersByIndexAndMergeCounts(
     ProtocolCryptor& protocol_cryptor, absl::string_view registers,
     const std::vector<std::string>& blinded_register_indexes,
-    absl::Span<const size_t> permutation, std::string& response) {
+    absl::Span<const size_t> permutation, int total_sketches_count,
+    std::string& response) {
   ASSIGN_OR_RETURN(size_t register_count,
                    GetNumberOfBlocks(registers, kBytesPerCipherRegister));
 
@@ -132,7 +137,7 @@ absl::Status JoinRegistersByIndexAndMergeCounts(
       // append the result to the response.
       RETURN_IF_ERROR(MergeCountsUsingSameKeyAggregation(
           permutation.subspan(start, i - start), registers, protocol_cryptor,
-          response));
+          total_sketches_count, response));
       // Reset the starting point.
       start = i;
     }
@@ -140,7 +145,7 @@ absl::Status JoinRegistersByIndexAndMergeCounts(
   // Process the last group and append the result to the response.
   return MergeCountsUsingSameKeyAggregation(
       permutation.subspan(start, register_count - start), registers,
-      protocol_cryptor, response);
+      protocol_cryptor, total_sketches_count, response);
 }
 
 absl::StatusOr<int64_t> EstimateReach(double liquid_legions_decay_rate,
@@ -657,7 +662,8 @@ CompleteExecutionPhaseOneAtAggregator(
   std::string* response_data = response.mutable_flag_count_tuples();
   RETURN_IF_ERROR(JoinRegistersByIndexAndMergeCounts(
       *protocol_cryptor, request.combined_register_vector(),
-      blinded_register_indexes, permutation, *response_data));
+      blinded_register_indexes, permutation, request.total_sketches_count(),
+      *response_data));
 
   // Add noise (flag_a, flag_b, flag_c, count) tuples if configured to.
   if (request.has_noise_parameters()) {
@@ -805,10 +811,6 @@ CompleteExecutionPhaseTwoAtAggregator(
         request.reach_dp_noise_baseline().contributors_count());
     int64_t global_reach_dp_noise_baseline = options.shift_offset * options.num;
     non_empty_register_count -= global_reach_dp_noise_baseline;
-    // Publisher noise and padding noise each contribute 1 additional destroyed
-    // register, which shouldn't be included when estimating reach.
-    // Subtracts 2 from the non_empty_register_count if noises exist.
-    non_empty_register_count -= 2;
   }
   if (request.has_frequency_noise_parameters()) {
     const FlagCountTupleNoiseGenerationParameters& noise_parameters =

--- a/cross-media-measurement/src/main/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv2/LiquidLegionsV2Mill.kt
+++ b/cross-media-measurement/src/main/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv2/LiquidLegionsV2Mill.kt
@@ -275,6 +275,7 @@ class LiquidLegionsV2Mill(
         compositeElGamalPublicKey = cryptoKeySet.clientPublicKey
         curveId = cryptoKeySet.curveId.toLong()
         combinedRegisterVector = readAndCombineAllInputBlobs(token, 1)
+        totalSketchesCount = token.computationDetails.liquidLegionsV2.totalRequisitionCount
       }
       if (noiseConfig.hasFrequencyNoiseConfig()) {
         requestBuilder.noiseParameters = GetFrequencyNoiseParams()

--- a/cross-media-measurement/src/main/proto/wfa/measurement/common/crypto/liquid_legions_v2_encryption_methods.proto
+++ b/cross-media-measurement/src/main/proto/wfa/measurement/common/crypto/liquid_legions_v2_encryption_methods.proto
@@ -153,6 +153,8 @@ message CompleteExecutionPhaseOneAtAggregatorRequest {
   // The parameters required for generating noise flag count tuples.
   // if unset, no noise would be added.
   FlagCountTupleNoiseGenerationParameters noise_parameters = 5;
+  // The total number of sketches across all workers for this computation.
+  int32 total_sketches_count = 6;
 }
 
 // The response of the CompleteExecutionPhaseOneAtAggregator method.

--- a/cross-media-measurement/src/test/kotlin/org/wfanet/measurement/common/crypto/liquidlegionsv2/LiquidLegionsV2EncryptionUtilityTest.kt
+++ b/cross-media-measurement/src/test/kotlin/org/wfanet/measurement/common/crypto/liquidlegionsv2/LiquidLegionsV2EncryptionUtilityTest.kt
@@ -117,6 +117,7 @@ class LiquidLegionsV2EncryptionUtilityTest {
         compositeElGamalPublicKey = CLIENT_EL_GAMAL_KEYS
         curveId = CURVE_ID
         combinedRegisterVector = completeExecutionPhaseOneResponse2.combinedRegisterVector
+        totalSketchesCount = 3
       }.build()
     val completeExecutionPhaseOneAtAggregatorResponse =
       CompleteExecutionPhaseOneAtAggregatorResponse.parseFrom(

--- a/cross-media-measurement/src/test/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv2/LiquidLegionsV2MillTest.kt
+++ b/cross-media-measurement/src/test/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv2/LiquidLegionsV2MillTest.kt
@@ -952,6 +952,7 @@ class LiquidLegionsV2MillTest {
           contributorsCount = WORKER_COUNT
           dpParams = testNoiseConfig.frequencyNoiseConfig
         }
+        totalSketchesCount = PUBLISHER_COUNT
       }.build()
     )
   }


### PR DESCRIPTION
Based on the noise parameters and number of publihers, there can be
thousands to hunderds of thousands publisher noise registers and padding
noise registers.

All publisher noise registers have the same register id, namely C1.
All padding noise registers have a same register id, namely C2.

After sameKeyAggregation, these two types of registers will be merged
into two registers respectively. These two registers will be fitlered
out later before estimating reach. In other words, there is no need to
aggregate these two types of noise registers at all.

This CL would skip aggregating any register group that contains more
than #publisher registers inside, which can only be true for register id
C1 and C2.

The change saves several percentage of total CPU time.