### PR TITLE
Use JDK instead of JRE for lint workflow.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: '11.0.10'
-        java-package: jre
+        java-package: jdk
         architecture: x64
 
     - name: Make linter directory


### PR DESCRIPTION
This should hopefully address issues with running google-java-formatter.