### PR TITLE
Re-randomize the paritially decrypted flags in LLV2 round 2.

### DIFF
--- a/any-sketch/src/main/cc/any_sketch/crypto/README.md
+++ b/any-sketch/src/main/cc/any_sketch/crypto/README.md
@@ -8,12 +8,12 @@ the combiner.
 ## Flag to set
 
 *   curve_id: the Elliptic curve id.
-*   elgamal_y_list: the list of ElGamal Y keys to combine.
+*   element_list: the list of elements to combine.
 
 ### Example
 
 ```
-combine_public_keys  --curve_id=415  --elgamal_y_list=02d1432ca007a6c6d739fce2d21feb56d9a2c35cf968265f9093c4b691e11386b3,039ef370ff4d216225401781d88a03f5a670a5040e6333492cb4e0cd991abbd5a3,02d0f25ab445fc9c29e7e2509adc93308430f432522ffa93c2ae737ceb480b66d7
+combine_public_keys  --curve_id=415  --element_list=02d1432ca007a6c6d739fce2d21feb56d9a2c35cf968265f9093c4b691e11386b3,039ef370ff4d216225401781d88a03f5a670a5040e6333492cb4e0cd991abbd5a3,02d0f25ab445fc9c29e7e2509adc93308430f432522ffa93c2ae737ceb480b66d7
 ```
 
 ## Expected output

--- a/cross-media-measurement/src/main/cc/wfa/measurement/common/crypto/constants.h
+++ b/cross-media-measurement/src/main/cc/wfa/measurement/common/crypto/constants.h
@@ -49,6 +49,10 @@ inline constexpr absl::string_view kGenerateWithNewPohligHellmanKey = "";
 inline constexpr absl::string_view kGenerateWithNewElGamalPrivateKey = "";
 inline const std::pair<std::string, std::string>
     kGenerateWithNewElGamalPublicKey = {"", ""};
+inline const std::pair<std::string, std::string> kGenerateNewCompositeCipher = {
+    "", ""};
+inline const std::pair<std::string, std::string>
+    kGenerateNewParitialCompositeCipher = {"", ""};
 
 }  // namespace wfa::measurement::common::crypto
 

--- a/cross-media-measurement/src/main/cc/wfa/measurement/common/crypto/constants.h
+++ b/cross-media-measurement/src/main/cc/wfa/measurement/common/crypto/constants.h
@@ -12,8 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef WFA_MEASUREMENT_COMMON_CRYPTO_CONSTANTS_H_
-#define WFA_MEASUREMENT_COMMON_CRYPTO_CONSTANTS_H_
+#ifndef SRC_MAIN_CC_WFA_MEASUREMENT_COMMON_CRYPTO_CONSTANTS_H_
+#define SRC_MAIN_CC_WFA_MEASUREMENT_COMMON_CRYPTO_CONSTANTS_H_
+
+#include <string>
+#include <utility>
 
 #include "absl/strings/string_view.h"
 
@@ -56,4 +59,4 @@ inline const std::pair<std::string, std::string>
 
 }  // namespace wfa::measurement::common::crypto
 
-#endif  // WFA_MEASUREMENT_COMMON_CRYPTO_CONSTANTS_H_
+#endif  // SRC_MAIN_CC_WFA_MEASUREMENT_COMMON_CRYPTO_CONSTANTS_H_

--- a/cross-media-measurement/src/main/cc/wfa/measurement/common/crypto/protocol_cryptor.cc
+++ b/cross-media-measurement/src/main/cc/wfa/measurement/common/crypto/protocol_cryptor.cc
@@ -14,6 +14,9 @@
 
 #include "wfa/measurement/common/crypto/protocol_cryptor.h"
 
+#include <string>
+#include <utility>
+
 #include "absl/memory/memory.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"

--- a/cross-media-measurement/src/main/cc/wfa/measurement/common/crypto/protocol_cryptor.cc
+++ b/cross-media-measurement/src/main/cc/wfa/measurement/common/crypto/protocol_cryptor.cc
@@ -39,6 +39,7 @@ class ProtocolCryptorImpl : public ProtocolCryptor {
   ProtocolCryptorImpl(
       std::unique_ptr<CommutativeElGamal> local_el_gamal_cipher,
       std::unique_ptr<CommutativeElGamal> client_el_gamal_cipher,
+      std::unique_ptr<CommutativeElGamal> partial_composite_el_gamal_cipher,
       std::unique_ptr<ECCommutativeCipher> local_pohlig_hellman_cipher,
       std::unique_ptr<Context> ctx, ECGroup ec_group);
   ~ProtocolCryptorImpl() override = default;
@@ -52,15 +53,17 @@ class ProtocolCryptorImpl : public ProtocolCryptor {
   absl::StatusOr<std::string> DecryptLocalElGamal(
       const ElGamalCiphertext& ciphertext) override;
   absl::StatusOr<ElGamalCiphertext> EncryptPlaintextCompositeElGamal(
-      absl::string_view plaintext) override;
+      absl::string_view plaintext, CompositeType composite_type) override;
   absl::StatusOr<ElGamalEcPointPair> EncryptPlaintextToEcPointsCompositeElGamal(
-      absl::string_view plaintext) override;
+      absl::string_view plaintext, CompositeType composite_type) override;
   absl::StatusOr<ElGamalEcPointPair>
-  EncryptIdentityElementToEcPointsCompositeElGamal() override;
+  EncryptIdentityElementToEcPointsCompositeElGamal(
+      CompositeType composite_type) override;
   absl::StatusOr<ElGamalCiphertext> EncryptCompositeElGamal(
-      absl::string_view plain_ec_point) override;
+      absl::string_view plain_ec_point, CompositeType composite_type) override;
   absl::StatusOr<ElGamalCiphertext> ReRandomize(
-      const ElGamalCiphertext& ciphertext) override;
+      const ElGamalCiphertext& ciphertext,
+      CompositeType composite_type) override;
   absl::StatusOr<ElGamalEcPointPair> CalculateDestructor(
       const ElGamalEcPointPair& base, const ElGamalEcPointPair& key) override;
   absl::StatusOr<std::string> MapToCurve(absl::string_view str) override;
@@ -82,6 +85,9 @@ class ProtocolCryptorImpl : public ProtocolCryptor {
   // A CommutativeElGamal cipher created using the combined public key, used
   // for re-randomizing ciphertext and sameKeyAggregation, etc.
   const std::unique_ptr<CommutativeElGamal> composite_el_gamal_cipher_;
+  // A CommutativeElGamal cipher created using the partially combined public
+  // key, used for re-randomizing partially decrypted ciphertexts.
+  const std::unique_ptr<CommutativeElGamal> partial_composite_el_gamal_cipher_;
   // An ECCommutativeCipher used for blinding a ciphertext.
   const std::unique_ptr<ECCommutativeCipher> local_pohlig_hellman_cipher_;
 
@@ -99,10 +105,13 @@ class ProtocolCryptorImpl : public ProtocolCryptor {
 ProtocolCryptorImpl::ProtocolCryptorImpl(
     std::unique_ptr<CommutativeElGamal> local_el_gamal_cipher,
     std::unique_ptr<CommutativeElGamal> client_el_gamal_cipher,
+    std::unique_ptr<CommutativeElGamal> partial_composite_el_gamal_cipher,
     std::unique_ptr<ECCommutativeCipher> local_pohlig_hellman_cipher,
     std::unique_ptr<Context> ctx, ECGroup ec_group)
     : local_el_gamal_cipher_(std::move(local_el_gamal_cipher)),
       composite_el_gamal_cipher_(std::move(client_el_gamal_cipher)),
+      partial_composite_el_gamal_cipher_(
+          std::move(partial_composite_el_gamal_cipher)),
       local_pohlig_hellman_cipher_(std::move(local_pohlig_hellman_cipher)),
       ctx_(std::move(ctx)),
       ec_group_(std::move(ec_group)) {}
@@ -126,39 +135,43 @@ absl::StatusOr<std::string> ProtocolCryptorImpl::DecryptLocalElGamal(
 
 absl::StatusOr<ElGamalCiphertext>
 ProtocolCryptorImpl::EncryptPlaintextCompositeElGamal(
-    absl::string_view plaintext) {
+    absl::string_view plaintext, CompositeType composite_type) {
   ASSIGN_OR_RETURN(std::string ec_point, MapToCurve(plaintext));
-  return EncryptCompositeElGamal(ec_point);
+  return EncryptCompositeElGamal(ec_point, composite_type);
 }
 
 absl::StatusOr<ElGamalEcPointPair>
 ProtocolCryptorImpl::EncryptPlaintextToEcPointsCompositeElGamal(
-    absl::string_view plaintext) {
+    absl::string_view plaintext, CompositeType composite_type) {
   ASSIGN_OR_RETURN(ElGamalCiphertext temp,
-                   EncryptPlaintextCompositeElGamal(plaintext));
+                   EncryptPlaintextCompositeElGamal(plaintext, composite_type));
   return ToElGamalEcPoints(temp);
 }
 
 absl::StatusOr<ElGamalEcPointPair>
-ProtocolCryptorImpl::EncryptIdentityElementToEcPointsCompositeElGamal() {
-  ASSIGN_OR_RETURN(ElGamalCiphertext temp,
-                   composite_el_gamal_cipher_->EncryptIdentityElement());
+ProtocolCryptorImpl::EncryptIdentityElementToEcPointsCompositeElGamal(
+    CompositeType composite_type) {
+  ASSIGN_OR_RETURN(
+      ElGamalCiphertext temp,
+      composite_type == CompositeType::kFull
+          ? composite_el_gamal_cipher_->EncryptIdentityElement()
+          : partial_composite_el_gamal_cipher_->EncryptIdentityElement());
   return ToElGamalEcPoints(temp);
 }
 
 absl::StatusOr<ElGamalCiphertext> ProtocolCryptorImpl::EncryptCompositeElGamal(
-    absl::string_view plain_ec_point) {
+    absl::string_view plain_ec_point, CompositeType composite_type) {
   absl::WriterMutexLock l(&mutex_);
-  return composite_el_gamal_cipher_->Encrypt(plain_ec_point);
+  return composite_type == CompositeType::kFull
+             ? composite_el_gamal_cipher_->Encrypt(plain_ec_point)
+             : partial_composite_el_gamal_cipher_->Encrypt(plain_ec_point);
 }
 
 absl::StatusOr<ElGamalCiphertext> ProtocolCryptorImpl::ReRandomize(
-    const ElGamalCiphertext& ciphertext) {
-  absl::WriterMutexLock l(&mutex_);
-  ASSIGN_OR_RETURN(ElGamalCiphertext zero,
-                   composite_el_gamal_cipher_->EncryptIdentityElement());
-  ASSIGN_OR_RETURN(ElGamalEcPointPair zero_ec,
-                   GetElGamalEcPoints(zero, ec_group_));
+    const ElGamalCiphertext& ciphertext, CompositeType composite_type) {
+  ASSIGN_OR_RETURN(
+      ElGamalEcPointPair zero_ec,
+      EncryptIdentityElementToEcPointsCompositeElGamal(composite_type));
   ASSIGN_OR_RETURN(ElGamalEcPointPair ciphertext_ec,
                    GetElGamalEcPoints(ciphertext, ec_group_));
   ASSIGN_OR_RETURN(ElGamalEcPointPair result_ec,
@@ -231,13 +244,27 @@ absl::Status ProtocolCryptorImpl::BatchProcess(absl::string_view data,
         result.append(temp);
         break;
       }
+      case Action::kPartialDecryptAndReRandomize: {
+        ASSIGN_OR_RETURN(std::string decrypted,
+                         DecryptLocalElGamal(ciphertext));
+        // Rerandomize the decrypted ciphertext such that it couldn't be
+        // distinguished by the first element.
+        ASSIGN_OR_RETURN(
+            ElGamalCiphertext temp,
+            ReRandomize(std::make_pair(ciphertext.first, decrypted),
+                        CompositeType::kPartial));
+        result.append(temp.first);
+        result.append(temp.second);
+        break;
+      }
       case Action::kDecrypt: {
         ASSIGN_OR_RETURN(std::string temp, DecryptLocalElGamal(ciphertext));
         result.append(temp);
         break;
       }
       case Action::kReRandomize: {
-        ASSIGN_OR_RETURN(ElGamalCiphertext temp, ReRandomize(ciphertext));
+        ASSIGN_OR_RETURN(ElGamalCiphertext temp,
+                         ReRandomize(ciphertext, CompositeType::kFull));
         result.append(temp.first);
         result.append(temp.second);
         break;
@@ -281,7 +308,8 @@ absl::StatusOr<std::unique_ptr<ProtocolCryptor>> CreateProtocolCryptorWithKeys(
     int curve_id, const ElGamalCiphertext& local_el_gamal_public_key,
     absl::string_view local_el_gamal_private_key,
     absl::string_view local_pohlig_hellman_private_key,
-    const ElGamalCiphertext& composite_el_gamal_public_key) {
+    const ElGamalCiphertext& composite_el_gamal_public_key,
+    const ElGamalCiphertext& partial_composite_el_gamal_public_key) {
   auto ctx = absl::make_unique<Context>();
   ASSIGN_OR_RETURN(ECGroup ec_group, ECGroup::Create(curve_id, ctx.get()));
   ASSIGN_OR_RETURN(
@@ -299,6 +327,11 @@ absl::StatusOr<std::unique_ptr<ProtocolCryptor>> CreateProtocolCryptorWithKeys(
                        ? CommutativeElGamal::CreateWithNewKeyPair(curve_id)
                        : CommutativeElGamal::CreateFromPublicKey(
                              curve_id, composite_el_gamal_public_key));
+  ASSIGN_OR_RETURN(auto partial_composite_el_gamal_cipher,
+                   partial_composite_el_gamal_public_key.first.empty()
+                       ? CommutativeElGamal::CreateWithNewKeyPair(curve_id)
+                       : CommutativeElGamal::CreateFromPublicKey(
+                             curve_id, partial_composite_el_gamal_public_key));
   ASSIGN_OR_RETURN(auto local_pohlig_hellman_cipher,
                    local_pohlig_hellman_private_key.empty()
                        ? ECCommutativeCipher::CreateWithNewKey(
@@ -310,6 +343,7 @@ absl::StatusOr<std::unique_ptr<ProtocolCryptor>> CreateProtocolCryptorWithKeys(
   std::unique_ptr<ProtocolCryptor> result =
       absl::make_unique<ProtocolCryptorImpl>(
           std::move(local_el_gamal_cipher), std::move(client_el_gamal_cipher),
+          std::move(partial_composite_el_gamal_cipher),
           std::move(local_pohlig_hellman_cipher), std::move(ctx),
           std::move(ec_group));
   return {std::move(result)};

--- a/cross-media-measurement/src/main/cc/wfa/measurement/common/crypto/protocol_cryptor.h
+++ b/cross-media-measurement/src/main/cc/wfa/measurement/common/crypto/protocol_cryptor.h
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef WFA_MEASUREMENT_COMMON_CRYPTO_PROTOCOL_CRYPTOR_H_
-#define WFA_MEASUREMENT_COMMON_CRYPTO_PROTOCOL_CRYPTOR_H_
+#ifndef SRC_MAIN_CC_WFA_MEASUREMENT_COMMON_CRYPTO_PROTOCOL_CRYPTOR_H_
+#define SRC_MAIN_CC_WFA_MEASUREMENT_COMMON_CRYPTO_PROTOCOL_CRYPTOR_H_
 
 #include <memory>
+#include <string>
 
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
@@ -116,4 +117,4 @@ absl::StatusOr<std::unique_ptr<ProtocolCryptor>> CreateProtocolCryptorWithKeys(
 
 }  // namespace wfa::measurement::common::crypto
 
-#endif  // WFA_MEASUREMENT_COMMON_CRYPTO_PROTOCOL_CRYPTOR_H_
+#endif  // SRC_MAIN_CC_WFA_MEASUREMENT_COMMON_CRYPTO_PROTOCOL_CRYPTOR_H_

--- a/cross-media-measurement/src/main/cc/wfa/measurement/protocol/liquid_legions_v1/liquid_legions_v1_encryption_utility.cc
+++ b/cross-media-measurement/src/main/cc/wfa/measurement/protocol/liquid_legions_v1/liquid_legions_v1_encryption_utility.cc
@@ -47,6 +47,7 @@ using ::private_join_and_compute::ECPoint;
 using ::wfa::common::ElGamalPublicKey;
 using ::wfa::measurement::common::SortStringByBlock;
 using ::wfa::measurement::common::crypto::Action;
+using ::wfa::measurement::common::crypto::CompositeType;
 using ::wfa::measurement::common::crypto::CreateProtocolCryptorWithKeys;
 using ::wfa::measurement::common::crypto::ElGamalEcPointPair;
 using ::wfa::measurement::common::crypto::ExtractElGamalCiphertextFromString;
@@ -56,6 +57,8 @@ using ::wfa::measurement::common::crypto::kBytesPerCipherRegister;
 using ::wfa::measurement::common::crypto::kBytesPerCipherText;
 using ::wfa::measurement::common::crypto::KeyCountPairCipherText;
 using ::wfa::measurement::common::crypto::kFlagZeroBase;
+using ::wfa::measurement::common::crypto::kGenerateNewCompositeCipher;
+using ::wfa::measurement::common::crypto::kGenerateNewParitialCompositeCipher;
 using ::wfa::measurement::common::crypto::kGenerateWithNewElGamalPublicKey;
 using ::wfa::measurement::common::crypto::kGenerateWithNewPohligHellmanKey;
 using ::wfa::measurement::common::crypto::kUnitECPointSeed;
@@ -122,7 +125,7 @@ absl::Status MergeCountsUsingSameKeyAggregation(
   // Initialize the flag and count.
   ASSIGN_OR_RETURN(ElGamalEcPointPair tuple_flag,
                    protocol_cryptor.EncryptPlaintextToEcPointsCompositeElGamal(
-                       kFlagZeroBase));
+                       kFlagZeroBase, CompositeType::kFull));
   ASSIGN_OR_RETURN(ElGamalEcPointPair tuple_count,
                    protocol_cryptor.ToElGamalEcPoints(key_count_0.count));
 
@@ -215,7 +218,8 @@ absl::StatusOr<BlindOneLayerRegisterIndexResponse> BlindOneLayerRegisterIndex(
           request.local_el_gamal_key_pair().secret_key(),
           kGenerateWithNewPohligHellmanKey,
           std::make_pair(request.composite_el_gamal_public_key().generator(),
-                         request.composite_el_gamal_public_key().element())),
+                         request.composite_el_gamal_public_key().element()),
+          kGenerateNewParitialCompositeCipher),
       "Failed to create the protocol cipher, invalid curveId or keys.");
 
   BlindOneLayerRegisterIndexResponse response;
@@ -257,7 +261,8 @@ BlindLastLayerIndexThenJoinRegisters(
           request.local_el_gamal_key_pair().secret_key(),
           kGenerateWithNewPohligHellmanKey,
           std::make_pair(request.composite_el_gamal_public_key().generator(),
-                         request.composite_el_gamal_public_key().element())),
+                         request.composite_el_gamal_public_key().element()),
+          kGenerateNewParitialCompositeCipher),
       "Failed to create the protocol cipher, invalid curveId or keys.");
 
   ASSIGN_OR_RETURN(
@@ -299,7 +304,8 @@ absl::StatusOr<DecryptOneLayerFlagAndCountResponse> DecryptOneLayerFlagAndCount(
               request.local_el_gamal_key_pair().public_key().generator(),
               request.local_el_gamal_key_pair().public_key().element()),
           request.local_el_gamal_key_pair().secret_key(),
-          kGenerateWithNewPohligHellmanKey, kGenerateWithNewElGamalPublicKey),
+          kGenerateWithNewPohligHellmanKey, kGenerateNewCompositeCipher,
+          kGenerateNewParitialCompositeCipher),
       "Failed to create the protocol cipher, invalid curveId or keys.");
 
   DecryptOneLayerFlagAndCountResponse response;

--- a/cross-media-measurement/src/test/cc/wfa/measurement/protocol/liquid_legions_v2/liquid_legions_v2_encryption_utility_test.cc
+++ b/cross-media-measurement/src/test/cc/wfa/measurement/protocol/liquid_legions_v2/liquid_legions_v2_encryption_utility_test.cc
@@ -437,12 +437,12 @@ class TestData {
     complete_execution_phase_two_request_1.set_flag_count_tuples(
         complete_execution_phase_one_at_aggregator_response
             .flag_count_tuples());
+    *complete_execution_phase_two_request_1
+         .mutable_partial_composite_el_gamal_public_key() =
+        duchy_2_3_composite_public_key_;
     if (frequency_noise_parameters != nullptr) {
       *complete_execution_phase_two_request_1.mutable_noise_parameters() =
           *frequency_noise_parameters;
-      *complete_execution_phase_two_request_1
-           .mutable_partial_composite_el_gamal_public_key() =
-          duchy_2_3_composite_public_key_;
     }
 
     ASSIGN_OR_RETURN(
@@ -461,12 +461,12 @@ class TestData {
     complete_execution_phase_two_request_2.set_curve_id(kTestCurveId);
     complete_execution_phase_two_request_2.set_flag_count_tuples(
         complete_execution_phase_two_response_1.flag_count_tuples());
+    *complete_execution_phase_two_request_2
+         .mutable_partial_composite_el_gamal_public_key() =
+        duchy_3_el_gamal_key_pair_.public_key();
     if (frequency_noise_parameters != nullptr) {
       *complete_execution_phase_two_request_2.mutable_noise_parameters() =
           *frequency_noise_parameters;
-      *complete_execution_phase_two_request_2
-           .mutable_partial_composite_el_gamal_public_key() =
-          duchy_3_el_gamal_key_pair_.public_key();
     }
 
     ASSIGN_OR_RETURN(
@@ -756,7 +756,7 @@ TEST(EndToEnd, SumOfCountsShouldBeCorrect) {
   EXPECT_NEAR(result.frequency_distribution[6], 1.0, 0.001);
 }
 
-TEST(EndToEnd, LocallyDistroyedRegisterShouldBeIgnored) {
+TEST(EndToEnd, LocallyDestroyedRegisterShouldBeIgnored) {
   TestData test_data;
   Sketch plain_sketch = CreateEmptyLiquidLegionsSketch();
   AddRegister(&plain_sketch, /*index=*/1, /*key=*/111, /*count=*/3);
@@ -775,7 +775,7 @@ TEST(EndToEnd, LocallyDistroyedRegisterShouldBeIgnored) {
   EXPECT_NEAR(result.frequency_distribution[3], 1.0, 0.001);
 }
 
-TEST(EndToEnd, CrossPublisherDistroyedRegistersShouldBeIgnored) {
+TEST(EndToEnd, CrossPublisherDestroyedRegistersShouldBeIgnored) {
   TestData test_data;
   Sketch plain_sketch = CreateEmptyLiquidLegionsSketch();
   AddRegister(&plain_sketch, /*index=*/1, /*key=*/111, /*count=*/3);

--- a/cross-media-measurement/src/test/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv2/crypto/LiquidLegionsV2EncryptionUtilityTest.kt
+++ b/cross-media-measurement/src/test/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv2/crypto/LiquidLegionsV2EncryptionUtilityTest.kt
@@ -133,6 +133,7 @@ class LiquidLegionsV2EncryptionUtilityTest {
         compositeElGamalPublicKey = CLIENT_EL_GAMAL_KEYS
         curveId = CURVE_ID
         flagCountTuples = completeExecutionPhaseOneAtAggregatorResponse.flagCountTuples
+        partialCompositeElGamalPublicKey = DUCHY_2_3_COMBINED_EL_GAMAL_KEYS
       }.build()
     val CompleteExecutionPhaseTwoResponse1 = CompleteExecutionPhaseTwoResponse.parseFrom(
       LiquidLegionsV2EncryptionUtility.completeExecutionPhaseTwo(
@@ -147,6 +148,7 @@ class LiquidLegionsV2EncryptionUtilityTest {
         compositeElGamalPublicKey = CLIENT_EL_GAMAL_KEYS
         curveId = CURVE_ID
         flagCountTuples = CompleteExecutionPhaseTwoResponse1.flagCountTuples
+        partialCompositeElGamalPublicKey = DUCHY_3_EL_GAMAL_KEYS.publicKey
       }.build()
     val completeExecutionPhaseTwoResponse2 = CompleteExecutionPhaseTwoResponse.parseFrom(
       LiquidLegionsV2EncryptionUtility.completeExecutionPhaseTwo(
@@ -335,52 +337,52 @@ class LiquidLegionsV2EncryptionUtilityTest {
 
     private const val CURVE_ID = 415L // NID_X9_62_prime256v1
     private const val MAX_COUNTER_VALUE = 10
-    private const val DUCHY_1_PK_G =
+    private const val COMMON_PK_G =
       "036b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296"
     private const val DUCHY_1_PK_Y =
       "02d1432ca007a6c6d739fce2d21feb56d9a2c35cf968265f9093c4b691e11386b3"
     private const val DUCHY_1_SK =
       "057b22ef9c4e9626c22c13daed1363a1e6a5b309a930409f8d131f96ea2fa888"
-    private const val DUCHY_2_PK_G =
-      "036b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296"
     private const val DUCHY_2_PK_Y =
       "039ef370ff4d216225401781d88a03f5a670a5040e6333492cb4e0cd991abbd5a3"
     private const val DUCHY_2_SK =
       "31cc32e7cd53ff24f2b64ae8c531099af9867ebf5d9a659f742459947caa29b0"
-    private const val DUCHY_3_PK_G =
-      "036b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296"
     private const val DUCHY_3_PK_Y =
       "02d0f25ab445fc9c29e7e2509adc93308430f432522ffa93c2ae737ceb480b66d7"
     private const val DUCHY_3_SK =
       "338cce0306416b70e901436cb9eca5ac758e8ff41d7b58dabadf8726608ca6cc"
-    private const val CLIENT_PK_G =
-      "036b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296"
     private const val CLIENT_PK_Y =
       "02505d7b3ac4c3c387c74132ab677a3421e883b90d4c83dc766e400fe67acc1f04"
+    private const val DUCHY_2_3_COMBINED_PK_Y =
+      "031887eb8e4d4290fa97601c1ef6cda80ab3d2fe82da39ef8ed2e846cc7866a3b0"
     private val DUCHY_1_EL_GAMAL_KEYS = ElGamalKeyPair.newBuilder().apply {
       publicKeyBuilder.apply {
-        generator = DUCHY_1_PK_G.hexAsByteString()
+        generator = COMMON_PK_G.hexAsByteString()
         element = DUCHY_1_PK_Y.hexAsByteString()
       }
       secretKey = DUCHY_1_SK.hexAsByteString()
     }.build()
     private val DUCHY_2_EL_GAMAL_KEYS = ElGamalKeyPair.newBuilder().apply {
       publicKeyBuilder.apply {
-        generator = DUCHY_2_PK_G.hexAsByteString()
+        generator = COMMON_PK_G.hexAsByteString()
         element = DUCHY_2_PK_Y.hexAsByteString()
       }
       secretKey = DUCHY_2_SK.hexAsByteString()
     }.build()
     private val DUCHY_3_EL_GAMAL_KEYS = ElGamalKeyPair.newBuilder().apply {
       publicKeyBuilder.apply {
-        generator = DUCHY_3_PK_G.hexAsByteString()
+        generator = COMMON_PK_G.hexAsByteString()
         element = DUCHY_3_PK_Y.hexAsByteString()
       }
       secretKey = DUCHY_3_SK.hexAsByteString()
     }.build()
     private val CLIENT_EL_GAMAL_KEYS = ElGamalPublicKey.newBuilder().apply {
-      generator = CLIENT_PK_G.hexAsByteString()
+      generator = COMMON_PK_G.hexAsByteString()
       element = CLIENT_PK_Y.hexAsByteString()
+    }.build()
+    private val DUCHY_2_3_COMBINED_EL_GAMAL_KEYS = ElGamalPublicKey.newBuilder().apply {
+      generator = COMMON_PK_G.hexAsByteString()
+      element = DUCHY_2_3_COMBINED_PK_Y.hexAsByteString()
     }.build()
   }
 }


### PR DESCRIPTION
This is to ensurance that the aggregator can not identify these tuples.