### PR TITLE
Reduce logging in RequisitionLinker daemon.

### DIFF
--- a/cross-media-measurement/src/main/kotlin/org/wfanet/measurement/kingdom/daemon/RequisitionLinker.kt
+++ b/cross-media-measurement/src/main/kotlin/org/wfanet/measurement/kingdom/daemon/RequisitionLinker.kt
@@ -33,10 +33,12 @@ suspend fun Daemon.runRequisitionLinker() {
     .pairAll { report -> daemonDatabaseServicesClient.buildRequisitionsForReport(report).asFlow() }
     .mapConcurrently(this, maxConcurrency) { (report, requisition) ->
       throttleAndLog {
-        logger.info("Creating requisition: $requisition")
         val actualRequisition = daemonDatabaseServicesClient.createRequisition(requisition)
 
-        logger.info("Associating requisition $actualRequisition to report $report")
+        logger.info(
+          "Associating requisition ${actualRequisition.externalRequisitionId} to report " +
+            report.externalReportId
+        )
         daemonDatabaseServicesClient.associateRequisitionToReport(actualRequisition, report)
       }
     }


### PR DESCRIPTION
This daemon is very chatty. It accounted for gigabytes of logging in a
month, none of which is actually very useful.

This change logs half as many messages and each message is significantly
smaller.