### PR TITLE
Drop dependencies on @debian_java_base, adding constraints for Distroless Java.

### DIFF
--- a/cross-media-measurement/.bazelrc
+++ b/cross-media-measurement/.bazelrc
@@ -10,6 +10,6 @@ build --javabase=@bazel_tools//tools/jdk:remote_jdk11
 # Target Java 8.
 build --java_toolchain=@bazel_tools//tools/jdk:toolchain_java8
 
+import %workspace%/container.bazelrc
 import %workspace%/remote.bazelrc
 import %workspace%/results.bazelrc
-import %workspace%/container.bazelrc

--- a/cross-media-measurement/WORKSPACE
+++ b/cross-media-measurement/WORKSPACE
@@ -18,6 +18,17 @@ load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
 bazel_skylib_workspace()
 
+# @platforms
+
+http_archive(
+    name = "platforms",
+    sha256 = "079945598e4b6cc075846f7fd6a9d0857c33a7afc0de868c2ccb96405225135d",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.4/platforms-0.0.4.tar.gz",
+        "https://github.com/bazelbuild/platforms/releases/download/0.0.4/platforms-0.0.4.tar.gz",
+    ],
+)
+
 # @com_google_protobuf
 http_archive(
     name = "com_google_protobuf",

--- a/cross-media-measurement/WORKSPACE
+++ b/cross-media-measurement/WORKSPACE
@@ -196,40 +196,6 @@ load(
 
 java_image_repositories()
 
-load("@io_bazel_rules_docker//container:container.bzl", "container_pull")
-
-# docker.io/debian:bullseye-slim
-container_pull(
-    name = "debian_bullseye",
-    digest = "sha256:8ab4e348f60ebd18b891593a531ded31cbbc3878f6e476116f3b49b15c199110",
-    registry = "docker.io",
-    repository = "debian",
-)
-
-# docker.io/library/ubuntu:18.04
-container_pull(
-    name = "ubuntu_18_04",
-    digest = "sha256:d1bf40f712c466317f5e06d38b3e7e4c98fef1229872bf6e2a8d1e01836c7ec4",
-    registry = "docker.io",
-    repository = "library/ubuntu",
-)
-
-# gcr.io/ads-open-measurement/bazel
-container_pull(
-    name = "bazel_image",
-    digest = "sha256:4d63678c47062af86b9149fd24985dfabf83db62dc9ff18b209337d5c321670b",
-    registry = "gcr.io",
-    repository = "ads-open-measurement/bazel",
-)
-
-# See //src/main/docker/base:push_java_base
-container_pull(
-    name = "debian_java_base",
-    digest = "sha256:c6746729103a1a306a1ed572012562496512a691b3b23c3abacd64ad503cebc2",
-    registry = "index.docker.io",
-    repository = "wfameasurement/java-base",
-)
-
 # APT key for Google cloud.
 # See https://cloud.google.com/sdk/docs/install
 http_file(

--- a/cross-media-measurement/WORKSPACE
+++ b/cross-media-measurement/WORKSPACE
@@ -321,25 +321,10 @@ http_file(
     ],
 )
 
-# Rules for swig wrapping.
-local_repository(
-    name = "wfa_rules_swig",
-    path = "../rules-swig",
-)
+# Halo dependencies.
+load("//build/halo:repositories.bzl", "halo_dependencies")
 
-# Public APIs for measurement system.
-local_repository(
-    name = "wfa_measurement_proto",
-    path = "../cross-media-measurement-api",
-)
-
-# AnySketch.
-local_repository(
-    name = "any_sketch",
-    path = "../any-sketch",
-)
-
-local_repository(
-    name = "any_sketch_java",
-    path = "../any-sketch-java",
+halo_dependencies(
+    revision = "5e44201b715433c48c0b6b31703177af21b65cf5",
+    sha256 = "c2de33f7818488020b8e71e7c6d985e934e7767eeefcad38830d27396b4f0b53",
 )

--- a/cross-media-measurement/build/BUILD.bazel
+++ b/cross-media-measurement/build/BUILD.bazel
@@ -1,9 +1,0 @@
-platform(
-    name = "platform",
-    constraint_values = [
-        "@bazel_tools//platforms:linux",
-        "@bazel_tools//platforms:x86_64",
-        "@bazel_tools//tools/cpp:clang",
-    ],
-    parents = ["@local_config_platform//:host"],
-)

--- a/cross-media-measurement/build/cloud_spanner_emulator/BUILD.external
+++ b/cross-media-measurement/build/cloud_spanner_emulator/BUILD.external
@@ -3,8 +3,8 @@ package(default_visibility = ["//visibility:public"])
 load("@bazel_skylib//rules:native_binary.bzl", "native_binary")
 
 RESTRICTIONS = [
-    "@bazel_tools//platforms:x86_64",
-    "@bazel_tools//platforms:linux",
+    "@platforms//os:linux",
+    "@platforms//cpu:x86_64",
 ]
 
 native_binary(

--- a/cross-media-measurement/build/cue/BUILD.external
+++ b/cross-media-measurement/build/cue/BUILD.external
@@ -3,8 +3,8 @@ package(default_visibility = ["//visibility:public"])
 load("@bazel_skylib//rules:native_binary.bzl", "native_binary")
 
 RESTRICTIONS = [
-    "@bazel_tools//platforms:x86_64",
-    "@bazel_tools//platforms:linux",
+    "@platforms//os:linux",
+    "@platforms//cpu:x86_64",
 ]
 
 native_binary(

--- a/cross-media-measurement/build/halo/repositories.bzl
+++ b/cross-media-measurement/build/halo/repositories.bzl
@@ -1,0 +1,41 @@
+# Copyright 2021 The Cross-Media Measurement Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Halo repository dependencies."""
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+_URL_TEMPLATE = "https://github.com/world-federation-of-advertisers/experimental/archive/{revision}.tar.gz"
+_PREFIX_TEMPLATE = "experimental-{revision}/{subtree}"
+_DEPENDENCIES = {
+    "any-sketch": "any_sketch",
+    "any-sketch-java": "any_sketch_java",
+    "cross-media-measurement-api": "wfa_measurement_proto",
+    "rules-swig": "wfa_rules_swig",
+}
+
+def halo_dependencies(revision, sha256):
+    urls = [_URL_TEMPLATE.format(revision = revision)]
+    prefix_template = _PREFIX_TEMPLATE.format(
+        revision = revision,
+        subtree = "{subtree}",
+    )
+
+    for (subtree, name) in _DEPENDENCIES.items():
+        http_archive(
+            name = name,
+            urls = urls,
+            sha256 = sha256,
+            strip_prefix = prefix_template.format(subtree = subtree),
+        )

--- a/cross-media-measurement/build/platforms/BUILD.bazel
+++ b/cross-media-measurement/build/platforms/BUILD.bazel
@@ -81,6 +81,14 @@ alias(
 )
 
 platform(
+    name = "ubuntu_18_04_rbe",
+    constraint_values = [
+        ":glibc_2_27",
+    ],
+    parents = ["//build/rbe/configs/config:platform"],
+)
+
+platform(
     name = "ubuntu_focal",
     constraint_values = [
         ":glibc_2_31",

--- a/cross-media-measurement/build/platforms/BUILD.bazel
+++ b/cross-media-measurement/build/platforms/BUILD.bazel
@@ -1,0 +1,94 @@
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+constraint_setting(name = "glibc_version")
+
+constraint_value(
+    name = "glibc_2_23",
+    constraint_setting = ":glibc_version",
+)
+
+constraint_value(
+    name = "glibc_2_27",
+    constraint_setting = ":glibc_version",
+)
+
+constraint_value(
+    name = "glibc_2_28",
+    constraint_setting = ":glibc_version",
+)
+
+constraint_value(
+    name = "glibc_2_31",
+    constraint_setting = ":glibc_version",
+)
+
+platform(
+    name = "linux_x86_64",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+    visibility = ["//visibility:private"],
+)
+
+platform(
+    name = "debian_buster",
+    constraint_values = [
+        ":glibc_2_28",
+    ],
+    parents = [":linux_x86_64"],
+)
+
+alias(
+    name = "distroless",
+    actual = ":debian_buster",
+)
+
+platform(
+    name = "debian_bullseye",
+    constraint_values = [
+        ":glibc_2_31",
+    ],
+    parents = [":debian_buster"],
+)
+
+platform(
+    name = "ubuntu_xenial",
+    constraint_values = [
+        ":glibc_2_23",
+    ],
+    parents = [":linux_x86_64"],
+)
+
+alias(
+    name = "ubuntu_16_04",
+    actual = ":ubuntu_xenial",
+)
+
+platform(
+    name = "ubuntu_bionic",
+    constraint_values = [
+        ":glibc_2_27",
+    ],
+    parents = [":ubuntu_xenial"],
+)
+
+alias(
+    name = "ubuntu_18_04",
+    actual = ":ubuntu_bionic",
+)
+
+platform(
+    name = "ubuntu_focal",
+    constraint_values = [
+        ":glibc_2_31",
+    ],
+    parents = [":ubuntu_bionic"],
+)
+
+alias(
+    name = "ubuntu_20_04",
+    actual = ":ubuntu_focal",
+)

--- a/cross-media-measurement/build/platforms/constraints.bzl
+++ b/cross-media-measurement/build/platforms/constraints.bzl
@@ -1,0 +1,25 @@
+# Copyright 2021 The Cross-Media Measurement Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Common sets of constraint values."""
+
+DISTROLESS_JAVA = [
+    "@platforms//os:linux",
+    "@platforms//cpu:x86_64",
+] + select({
+    "//build/platforms:glibc_2_23": [],
+    "//build/platforms:glibc_2_27": [],
+    "//build/platforms:glibc_2_28": [],
+    "//conditions:default": ["@platforms//:incompatible"],
+})

--- a/cross-media-measurement/container.bazelrc
+++ b/cross-media-measurement/container.bazelrc
@@ -7,6 +7,6 @@ build:container --javabase=//build/rbe/configs/java:jdk
 build:container --crosstool_top=//build/rbe/configs/cc:toolchain
 build:container --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 build:container --extra_toolchains=//build/rbe/configs/config:cc-toolchain
-build:container --extra_execution_platforms=//build:platform
-build:container --host_platform=//build:platform
-build:container --platforms=//build:platform
+build:container --extra_execution_platforms=//build/platforms:ubuntu_18_04_rbe
+build:container --host_platform=//build/platforms:ubuntu_18_04_rbe
+build:container --platforms=//build/platforms:ubuntu_18_04_rbe

--- a/cross-media-measurement/remote.bazelrc
+++ b/cross-media-measurement/remote.bazelrc
@@ -10,8 +10,6 @@ build:remote --jobs=200
 
 # Set several flags related to specifying the platform, toolchain and java
 # properties.
-# These flags should only be used as is for the rbe-ubuntu16-04 container
-# and need to be adapted to work with other toolchain containers.
 build:remote --host_javabase=//build/rbe/configs/java:jdk
 build:remote --javabase=//build/rbe/configs/java:jdk
 build:remote --crosstool_top=//build/rbe/configs/cc:toolchain
@@ -21,9 +19,9 @@ build:remote --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 # by "extra_execution_platforms", "host_platform" and "platforms".
 # More about platforms: https://docs.bazel.build/versions/master/platforms.html
 build:remote --extra_toolchains=//build/rbe/configs/config:cc-toolchain
-build:remote --extra_execution_platforms=//build/rbe/configs/config:platform
-build:remote --host_platform=//build/rbe/configs/config:platform
-build:remote --platforms=//build/rbe/configs/config:platform
+build:remote --extra_execution_platforms=//build/platforms:ubuntu_18_04_rbe
+build:remote --host_platform=//build/platforms:ubuntu_18_04_rbe
+build:remote --platforms=//build/platforms:ubuntu_18_04_rbe
 
 # Starting with Bazel 0.27.0 strategies do not need to be explicitly
 # defined. See https://github.com/bazelbuild/bazel/issues/7480

--- a/cross-media-measurement/remote.bazelrc
+++ b/cross-media-measurement/remote.bazelrc
@@ -8,20 +8,8 @@
 # for a remote machine to execute them.
 build:remote --jobs=200
 
-# Set several flags related to specifying the platform, toolchain and java
-# properties.
-build:remote --host_javabase=//build/rbe/configs/java:jdk
-build:remote --javabase=//build/rbe/configs/java:jdk
-build:remote --crosstool_top=//build/rbe/configs/cc:toolchain
-build:remote --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
-# Platform flags:
-# The toolchain container used for execution is defined in the target indicated
-# by "extra_execution_platforms", "host_platform" and "platforms".
-# More about platforms: https://docs.bazel.build/versions/master/platforms.html
-build:remote --extra_toolchains=//build/rbe/configs/config:cc-toolchain
-build:remote --extra_execution_platforms=//build/platforms:ubuntu_18_04_rbe
-build:remote --host_platform=//build/platforms:ubuntu_18_04_rbe
-build:remote --platforms=//build/platforms:ubuntu_18_04_rbe
+# Include container toolchain/platform configuration.
+build:remote --config=container
 
 # Starting with Bazel 0.27.0 strategies do not need to be explicitly
 # defined. See https://github.com/bazelbuild/bazel/issues/7480

--- a/cross-media-measurement/src/main/kotlin/org/wfanet/measurement/duchy/deploy/common/daemon/mill/liquidlegionsv1/BUILD.bazel
+++ b/cross-media-measurement/src/main/kotlin/org/wfanet/measurement/duchy/deploy/common/daemon/mill/liquidlegionsv1/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
 load("@rules_java//java:defs.bzl", "java_binary")
 load("@io_bazel_rules_docker//java:image.bzl", "java_image")
+load("//build/platforms:constraints.bzl", "DISTROLESS_JAVA")
 
 kt_jvm_library(
     name = "liquid_legions_v1_mill_daemon",
@@ -49,8 +50,8 @@ java_binary(
 
 java_image(
     name = "forwarded_storage_liquid_legions_v1_mill_daemon_image",
-    base = "@debian_java_base//image",
     main_class = "org.wfanet.measurement.duchy.deploy.common.daemon.mill.liquidlegionsv1.ForwardedStorageLiquidLegionsV1MillDaemonKt",
+    target_compatible_with = DISTROLESS_JAVA,
     visibility = ["//src:docker_image_deployment"],
     runtime_deps = [":forwarded_storage_liquid_legions_v1_mill_daemon"],
 )

--- a/cross-media-measurement/src/main/kotlin/org/wfanet/measurement/duchy/deploy/common/daemon/mill/liquidlegionsv2/BUILD.bazel
+++ b/cross-media-measurement/src/main/kotlin/org/wfanet/measurement/duchy/deploy/common/daemon/mill/liquidlegionsv2/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
 load("@rules_java//java:defs.bzl", "java_binary")
 load("@io_bazel_rules_docker//java:image.bzl", "java_image")
+load("//build/platforms:constraints.bzl", "DISTROLESS_JAVA")
 
 kt_jvm_library(
     name = "liquid_legions_v2_mill_daemon",
@@ -49,8 +50,8 @@ java_binary(
 
 java_image(
     name = "forwarded_storage_liquid_legions_v2_mill_daemon_image",
-    base = "@debian_java_base//image",
     main_class = "org.wfanet.measurement.duchy.deploy.common.daemon.mill.liquidlegionsv2.ForwardedStorageLiquidLegionsV2MillDaemonKt",
+    target_compatible_with = DISTROLESS_JAVA,
     visibility = ["//src:docker_image_deployment"],
     runtime_deps = [":forwarded_storage_liquid_legions_v2_mill_daemon"],
 )

--- a/cross-media-measurement/src/main/kotlin/org/wfanet/measurement/duchy/deploy/gcloud/daemon/mill/liquidlegionsv1/BUILD.bazel
+++ b/cross-media-measurement/src/main/kotlin/org/wfanet/measurement/duchy/deploy/gcloud/daemon/mill/liquidlegionsv1/BUILD.bazel
@@ -2,6 +2,7 @@ load("//build:defs.bzl", "test_target")
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
 load("@rules_java//java:defs.bzl", "java_binary")
 load("@io_bazel_rules_docker//java:image.bzl", "java_image")
+load("//build/platforms:constraints.bzl", "DISTROLESS_JAVA")
 
 package(default_visibility = [
     test_target(":__pkg__"),
@@ -29,8 +30,8 @@ java_binary(
 
 java_image(
     name = "gcs_liquid_legions_v1_mill_daemon_image",
-    base = "@debian_java_base//image",
     main_class = "org.wfanet.measurement.duchy.deploy.gcloud.daemon.mill.liquidlegionsv1.GcsLiquidLegionsV1MillDaemonKt",
+    target_compatible_with = DISTROLESS_JAVA,
     visibility = ["//src:docker_image_deployment"],
     runtime_deps = [":gcs_liquid_legions_v1_mill_daemon"],
 )

--- a/cross-media-measurement/src/main/kotlin/org/wfanet/measurement/duchy/deploy/gcloud/daemon/mill/liquidlegionsv2/BUILD.bazel
+++ b/cross-media-measurement/src/main/kotlin/org/wfanet/measurement/duchy/deploy/gcloud/daemon/mill/liquidlegionsv2/BUILD.bazel
@@ -2,6 +2,7 @@ load("//build:defs.bzl", "test_target")
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
 load("@rules_java//java:defs.bzl", "java_binary")
 load("@io_bazel_rules_docker//java:image.bzl", "java_image")
+load("//build/platforms:constraints.bzl", "DISTROLESS_JAVA")
 
 package(default_visibility = [
     test_target(":__pkg__"),
@@ -29,8 +30,8 @@ java_binary(
 
 java_image(
     name = "gcs_liquid_legions_v2_mill_daemon_image",
-    base = "@debian_java_base//image",
     main_class = "org.wfanet.measurement.duchy.deploy.gcloud.daemon.mill.liquidlegionsv2.GcsLiquidLegionsV2MillDaemonKt",
+    target_compatible_with = DISTROLESS_JAVA,
     visibility = ["//src:docker_image_deployment"],
     runtime_deps = [":gcs_liquid_legions_v2_mill_daemon"],
 )

--- a/cross-media-measurement/src/main/kotlin/org/wfanet/measurement/loadtest/BUILD.bazel
+++ b/cross-media-measurement/src/main/kotlin/org/wfanet/measurement/loadtest/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_java//java:defs.bzl", "java_binary")
 load("//build:defs.bzl", "test_target")
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
 load("@io_bazel_rules_docker//java:image.bzl", "java_image")
+load("//build/platforms:constraints.bzl", "DISTROLESS_JAVA")
 
 package(default_visibility = [
     ":__subpackages__",
@@ -85,18 +86,18 @@ java_binary(
 
 java_image(
     name = "filesystem_storage_correctness_runner_image",
-    base = "@debian_java_base//image",
     data = ["//src/main/kotlin/org/wfanet/measurement/loadtest/config"],
     main_class = "org.wfanet.measurement.loadtest.FilesystemStorageCorrectnessRunnerKt",
+    target_compatible_with = DISTROLESS_JAVA,
     visibility = ["//src:docker_image_deployment"],
     runtime_deps = [":file_system_storage_correctness_runner"],
 )
 
 java_image(
     name = "gcs_correctness_runner_image",
-    base = "@debian_java_base//image",
     data = ["//src/main/kotlin/org/wfanet/measurement/loadtest/config"],
     main_class = "org.wfanet.measurement.loadtest.GcsCorrectnessRunnerKt",
+    target_compatible_with = DISTROLESS_JAVA,
     visibility = ["//src:docker_image_deployment"],
     runtime_deps = [":gcs_correctness_runner"],
 )


### PR DESCRIPTION
This requires that java_image targets that depend on JNI for protocol encryption be built on a platform that has an appropriate version of glibc. The host platform can be specified using the `--host_platform` option to the Bazel CLI. For example, Ubuntu 18.04 "bionic" can be specified using `--host_platform=//build/platforms:ubuntu_18_04`.

If using the included RBE or Bazel container configuration, this will already be specified correctly.