### PR TITLE
Allow build and test workflow to be run manually.

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -19,6 +19,11 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    types: [opened, synchronize, edited]
+  workflow_dispatch:
+
+env:
+  restore_cache: ${{ github.event_name != 'workflow_dispatch' }}
 
 jobs:
   any-sketch:
@@ -29,9 +34,10 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Bazel build and test
-      uses: world-federation-of-advertisers/actions/bazel-build-test@main
+      uses: world-federation-of-advertisers/actions/bazel-build-test@v1.1.0-rc2
       with:
         workspace-path: ${{ github.job }}
+        restore-cache: ${{ env.restore_cache }}
   any-sketch-java:
     name: Build and test any-sketch-java targets
     runs-on: ubuntu-20.04
@@ -40,9 +46,10 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Bazel build and test
-      uses: world-federation-of-advertisers/actions/bazel-build-test@main
+      uses: world-federation-of-advertisers/actions/bazel-build-test@v1.1.0-rc2
       with:
         workspace-path: ${{ github.job }}
+        restore-cache: ${{ env.restore_cache }}
   cross-media-measurement:
     name: Build and test cross-media-measurement targets
     runs-on: ubuntu-20.04
@@ -51,9 +58,10 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Bazel build and test
-      uses: world-federation-of-advertisers/actions/bazel-build-test@main
+      uses: world-federation-of-advertisers/actions/bazel-build-test@v1.1.0-rc2
       with:
         workspace-path: ${{ github.job }}
+        restore-cache: ${{ env.restore_cache }}
   cross-media-measurement-api:
     name: Build and test cross-media-measurement-api targets
     runs-on: ubuntu-20.04
@@ -62,8 +70,9 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Bazel build and test
-      uses: world-federation-of-advertisers/actions/bazel-build-test@main
+      uses: world-federation-of-advertisers/actions/bazel-build-test@v1.1.0-rc2
       with:
+        restore-cache: ${{ env.restore_cache }}
         workspace-path: ${{ github.job }}
   examples:
     name: Build and test examples targets
@@ -73,6 +82,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Bazel build and test
-      uses: world-federation-of-advertisers/actions/bazel-build-test@main
+      uses: world-federation-of-advertisers/actions/bazel-build-test@v1.1.0-rc2
       with:
+        restore-cache: ${{ env.restore_cache }}
         workspace-path: ${{ github.job }}


### PR DESCRIPTION
Manual runs will not restore the Bazel workspace cache.